### PR TITLE
Update pipewire config in ubuntu 24.04 wayland image to enable audiot…

### DIFF
--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -332,6 +332,7 @@ build {
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-gui/fxci/01-bootstrap.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-gui/fxci/02-additional-packages.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-gui/fxci/04-wayland.sh",
+      "${path.cwd}/scripts/linux/ubuntu-2404-amd64-gui/fxci/05-pipewire.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-gui/fxci/99-additional-talos-reqs.sh"
     ]
   }

--- a/scripts/linux/ubuntu-2404-amd64-gui/fxci/05-pipewire.sh
+++ b/scripts/linux/ubuntu-2404-amd64-gui/fxci/05-pipewire.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -exv
+
+# enable audiotestsrc plugin in pipewire config
+# used by gecko media tests to create dummy sound sources
+sed -e '/^context.spa-libs = {/,/^}$/ s/#\(audiotestsrc\)/\1/' /usr/share/pipewire/pipewire.conf > /etc/pipewire/pipewire.conf


### PR DESCRIPTION
…estsrc

Replacing the pulseaudio module-sine-source requires this plugin.

cc @padenot