### PR TITLE
ubuntu-2404-amd64{,-x11,-gui}: don't install gnome-initial-setup

### DIFF
--- a/scripts/linux/ubuntu-2404-amd64-gui/fxci/01-bootstrap.sh
+++ b/scripts/linux/ubuntu-2404-amd64-gui/fxci/01-bootstrap.sh
@@ -122,7 +122,7 @@ EOF
 
 systemctl enable worker
 
-retry apt-get install -y ubuntu-desktop ubuntu-gnome-desktop podman
+retry apt-get install -y ubuntu-desktop ubuntu-gnome-desktop podman gnome-initial-setup-
 
 # this is neccessary in GCP because after installing gnome desktop both NetworkManager and systemd-networkd are enabled
 # which leads to https://bugs.launchpad.net/ubuntu/jammy/+source/systemd/+bug/2036358

--- a/scripts/linux/ubuntu-2404-amd64-x11/fxci/01-bootstrap.sh
+++ b/scripts/linux/ubuntu-2404-amd64-x11/fxci/01-bootstrap.sh
@@ -122,7 +122,7 @@ EOF
 
 systemctl enable worker
 
-retry apt-get install -y ubuntu-desktop ubuntu-gnome-desktop podman
+retry apt-get install -y ubuntu-desktop ubuntu-gnome-desktop podman gnome-initial-setup-
 
 # this is neccessary in GCP because after installing gnome desktop both NetworkManager and systemd-networkd are enabled
 # which leads to https://bugs.launchpad.net/ubuntu/jammy/+source/systemd/+bug/2036358

--- a/scripts/linux/ubuntu-2404-amd64/fxci/01-bootstrap.sh
+++ b/scripts/linux/ubuntu-2404-amd64/fxci/01-bootstrap.sh
@@ -122,7 +122,7 @@ EOF
 
 systemctl enable worker
 
-retry apt-get install -y ubuntu-desktop ubuntu-gnome-desktop podman
+retry apt-get install -y ubuntu-desktop ubuntu-gnome-desktop podman gnome-initial-setup-
 
 # this is neccessary in GCP because after installing gnome desktop both NetworkManager and systemd-networkd are enabled
 # which leads to https://bugs.launchpad.net/ubuntu/jammy/+source/systemd/+bug/2036358


### PR DESCRIPTION
We don't want the gnome setup wizard showing up on the desktop when running tasks.