### PR TITLE
fix: remove runc from headless install

### DIFF
--- a/scripts/linux/ubuntu-2404-amd64-headless/fxci/05-nvidia-cuda.sh
+++ b/scripts/linux/ubuntu-2404-amd64-headless/fxci/05-nvidia-cuda.sh
@@ -46,11 +46,9 @@ apt-get install -y \
     libseccomp-dev \
     libtool \
     pkg-config \
-    runc \
     squashfs-tools \
     squashfs-tools-ng \
     uidmap \
-    wget \
     zlib1g-dev
 
 # install deb


### PR DESCRIPTION
This is causing docker to get uninstalled, breaking d2g tasks. Also remove wget, because it's clearly already installed.