### PR TITLE
feat: install nvidia headless server driver on ubuntu 24.04 headless image

### DIFF
--- a/scripts/linux/ubuntu-2404-amd64-headless/fxci/07-nvidia-driver-server.sh
+++ b/scripts/linux/ubuntu-2404-amd64-headless/fxci/07-nvidia-driver-server.sh
@@ -1,0 +1,1 @@
+apt-get -y install nvidia-headless-550-server


### PR DESCRIPTION
My hope is that this will fix https://mozilla-hub.atlassian.net/browse/RELOPS-1151, if it's even sensible to do at all.