### PR TITLE
ubuntu-2404-amd64-{headless,gui}: allow unprivileged user namespaces

### DIFF
--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -258,6 +258,7 @@ build {
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-gui/fxci/01-bootstrap.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-gui/fxci/02-additional-packages.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-gui/fxci/04-wayland.sh",
+      "${path.cwd}/scripts/linux/common/userns.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-gui/fxci/99-additional-talos-reqs.sh"
     ]
   }
@@ -485,6 +486,7 @@ build {
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-headless/fxci/01-bootstrap.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-headless/fxci/02-additional-packages.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-headless/fxci/03-aslr.sh",
+      "${path.cwd}/scripts/linux/common/userns.sh",
       "${path.cwd}/scripts/linux/common/v4l2loopback.sh"
     ]
   }

--- a/scripts/linux/common/userns.sh
+++ b/scripts/linux/common/userns.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2046844
+# The firefox sandbox relies on unprivileged user namespaces
+echo 'kernel.apparmor_restrict_unprivileged_userns = 0' > /etc/sysctl.d/90-userns.conf


### PR DESCRIPTION
Firefox sandboxing relies on them, and displays a warning when they're not available (https://bugzilla.mozilla.org/show_bug.cgi?id=1899516).