### PR TITLE
chore: bump 24.04 linux to Taskcluster 77.1.0

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 77.0.0
+  taskcluster_version: 77.1.0
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-amd64-gui"

--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 77.0.0
+  taskcluster_version: 77.1.0
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
Most notably, this picks up https://github.com/taskcluster/taskcluster/pull/7428, which should unblock us migrating more translations workers to the headless image.