### PR TITLE
chore: upgrade taskcluster on ubuntu 24.04 to 78.0.0

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 77.3.1
+  taskcluster_version: 78.0.0
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
This version contains a massive performance improvement for caches: https://github.com/taskcluster/taskcluster/pull/7451