### PR TITLE
chore: upgrade 24.04 headless image to taskcluster 81.0.3

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 78.0.0
+  taskcluster_version: 81.0.3
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
This picks up the fix for https://github.com/taskcluster/taskcluster/issues/7014, which I've been waiting for before switching translations GPU workers to this image.