### PR TITLE
feat: :sparkles: Update Windows Images to 1.0.2

### DIFF
--- a/config/win10-64-2009.yaml
+++ b/config/win10-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win10_64_2009"
   image_name: "win10_64_2009"
-  image_version: 1.0.1
+  image_version: 1.0.2
 azure:
   managed_image_resource_group_name: rg-packer-worker-images
   managed_image_storage_account_type: Standard_LRS
@@ -25,8 +25,8 @@ azure:
     - westus2
     - westus3
 vm:
-  puppet_version: 8.5.1
-  git_version: 2.46.0
+  puppet_version: 8.10.0
+  git_version: 2.48.1
   size: Standard_F8s_v2
   tags:
     base_image: win10642009azure
@@ -34,7 +34,7 @@ vm:
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
     sourceBranch: windows
-    deploymentId: "1a0441f"
+    deploymentId: "b1f4165"
     managed_by: packer
 tests:
   - microsoft_tools_tester.tests.ps1

--- a/config/win11-64-2009.yaml
+++ b/config/win11-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_64_2009"
   image_name: "win11_64_2009"
-  image_version: 1.0.0
+  image_version: 1.0.2
 azure:
   managed_image_resource_group_name: rg-packer-worker-images
   managed_image_storage_account_type: Standard_LRS
@@ -25,7 +25,8 @@ azure:
     - westus2
     - westus3
 vm:
-  puppet_version: 8.5.1
+  puppet_version: 8.10.0
+  git_version: 2.48.1
   size: Standard_F8s_v2
   tags:
     base_image: win11642009azure
@@ -33,7 +34,7 @@ vm:
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
     sourceBranch: windows
-    deploymentId: "8346140"
+    deploymentId: "b1f4165"
     managed_by: packer
 tests:
   - microsoft_tools_tester.tests.ps1

--- a/config/win11-64-24h2.yaml
+++ b/config/win11-64-24h2.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_64_24h2"
   image_name: "win11_64_24h2"
-  image_version: 1.0.1
+  image_version: 1.0.2
 azure:
   managed_image_resource_group_name: rg-packer-worker-images
   managed_image_storage_account_type: Standard_LRS
@@ -25,16 +25,16 @@ azure:
     - westus2
     - westus3
 vm:
-  puppet_version: 8.5.1
-  git_version: 2.46.0
+  puppet_version: 8.10.0
+  git_version: 2.48.1
   size: Standard_F8s_v2
   tags:
     base_image: win116424h2azure
     worker_pool_id: win11-64-24h2
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
-    sourceBranch: "windows"
-    deploymentId: "189d045"
+    sourceBranch: windows
+    deploymentId: "b1f4165"
     managed_by: packer
 tests:
   - microsoft_tools_tester.tests.ps1

--- a/config/win11-a64-24h2-builder.yaml
+++ b/config/win11-a64-24h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_24h2_builder"
   image_name: "win11_a64_24h2_builder"
-  image_version: 1.0.1
+  image_version: 1.0.2
 azure:
   managed_image_resource_group_name: rg-packer-worker-images
   managed_image_storage_account_type: Standard_LRS
@@ -15,8 +15,8 @@ azure:
   locations:
     - centralus
 vm:
-  puppet_version: 8.5.1
-  git_version: 2.46.0
+  puppet_version: 8.10.0
+  git_version: 2.48.1
   size: Standard_E8pds_v5
   tags:
     base_image: win11a6424h2azurebuilder
@@ -24,7 +24,7 @@ vm:
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
     sourceBranch: windows
-    deploymentId: "1a0441f"
+    deploymentId: "b1f4165"
     managed_by: packer
 tests:
   - microsoft_tools_builder-a64.tests.ps1

--- a/config/win11-a64-24h2-tester.yaml
+++ b/config/win11-a64-24h2-tester.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_24h2_tester"
   image_name: "win11_a64_24h2_tester"
-  image_version: 1.0.1
+  image_version: 1.0.2
 azure:
   managed_image_resource_group_name: rg-packer-worker-images
   managed_image_storage_account_type: Standard_LRS
@@ -15,8 +15,8 @@ azure:
   locations:
     - centralus
 vm:
-  puppet_version: 8.5.1
-  git_version: 2.46.0
+  puppet_version: 8.10.0
+  git_version: 2.48.1
   size: Standard_E8pds_v5
   tags:
     base_image: win11a6424h2azuretester
@@ -24,7 +24,7 @@ vm:
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
     sourceBranch: windows
-    deploymentId: "189d045"
+    deploymentId: "b1f4165"
     managed_by: packer
 tests:
   - microsoft_tools_tester.tests.ps1

--- a/config/win2022-64-2009.yaml
+++ b/config/win2022-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win2022_64_2009"
   image_name: "win2022_64_2009"
-  image_version: 1.0.1
+  image_version: 1.0.2
 azure:
   managed_image_resource_group_name: rg-packer-worker-images
   managed_image_storage_account_type: Standard_LRS
@@ -20,8 +20,8 @@ azure:
     - westus
     - westus2
 vm:
-  puppet_version: 8.5.1
-  git_version: 2.46.0
+  puppet_version: 8.10.0
+  git_version: 2.48.1
   size: Standard_F32s_v2
   tags:
     base_image: win2022642009azure
@@ -29,7 +29,7 @@ vm:
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
     sourceBranch: windows
-    deploymentId: "189d045"
+    deploymentId: "b1f4165"
     managed_by: packer
 tests:
   - microsoft_tools_builder.tests.ps1


### PR DESCRIPTION
* Taskcluster binaries are now running v81.0.3
* Updated Git to v2.48.1
* Updated Puppet to v8.10.0
* Removed procmon and sublime text
* Removed Powershell Profile Customizations
* Removed runTasksAsCurrentUser

Treeherder Pushes

win10-64-2009: https://treeherder.mozilla.org/jobs?repo=try&revision=da9fe81993154d0dad36505a1eac08cbed428a19
win11-64-2009: https://treeherder.mozilla.org/jobs?repo=try&revision=b525b8f7e087ac061185c3e099017b20326bc7a5
win11-64-24h2: waiting to finish https://treeherder.mozilla.org/jobs?repo=try&revision=07da81cbfc6abe2e21e32f43b9217da9baff67b5
win11-a64-24h2: https://treeherder.mozilla.org/jobs?repo=try&revision=b11a9eb2f4fbd4713e5d3774257b5edb85c606db
win11-a64-24h2-builder: https://treeherder.mozilla.org/jobs?repo=try&revision=1ad27c860267aa5e1c023d37e3636b875c5038ed
win11-64-24h2-hw: https://treeherder.mozilla.org/jobs?repo=try&revision=a38fa343c8b4404ea35631a6a40000a0246ccb53
win11-64-24h2-hw-ref: https://treeherder.mozilla.org/jobs?repo=try&revision=f6dfc057a04b0041f886ad5c0e0739da3e3d26b8
win2022: https://treeherder.mozilla.org/jobs?repo=try&revision=d566ac0206a39df883e155a20468f9e44deb1b35