### PR TITLE
ubuntu-2404-amd64-headless-alpha: set up local ssd and configure docker

### DIFF
--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -218,6 +218,8 @@ build {
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-headless/fxci/01-bootstrap.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-headless/fxci/02-additional-packages.sh",
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-headless/fxci/03-aslr.sh",
+      "${path.cwd}/scripts/linux/ubuntu-2404-amd64-headless/fxci/07-docker-config.sh",
+      "${path.cwd}/scripts/linux/common/80-ephemeral-disks.sh",
       "${path.cwd}/scripts/linux/common/userns.sh",
       "${path.cwd}/scripts/linux/common/v4l2loopback.sh"
     ]

--- a/scripts/linux/common/80-ephemeral-disks.sh
+++ b/scripts/linux/common/80-ephemeral-disks.sh
@@ -53,6 +53,18 @@ else
     echo "/mnt is now using nvme0n* devices."
 fi
 
+echo "Creating directories for generic-worker"
+# tasksDir (/home)
+mkdir -p /mnt/home
+mount -o bind /mnt/home /home
+# cachesDir
+mkdir -p /mnt/generic-worker/caches
+# downloadsDir
+mkdir -p /mnt/generic-worker/downloads
+
+echo "Creating docker specific directories"
+mkdir -p /mnt/var/lib/docker
+
 EOF
 
 file "${disk_setup_script}"
@@ -61,7 +73,7 @@ chmod +x "${disk_setup_script}"
 cat << EOF > /etc/systemd/system/generic-worker-disk-setup.service
 [Unit]
 Description=Taskcluster generic worker ephemeral disk setup
-Before=worker.service
+Before=worker.service docker.service
 
 [Service]
 Type=oneshot

--- a/scripts/linux/ubuntu-2404-amd64-headless/fxci/07-docker-config.sh
+++ b/scripts/linux/ubuntu-2404-amd64-headless/fxci/07-docker-config.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -exv
+
+# Configure docker to:
+# 1) use /mnt for storage, which will be on fast ssds if available rather than
+#    on the slower persistent drive
+# 2) turn on ipv6
+# 3) disable direct communication between containers
+
+cat << EOF > /etc/docker/daemon.json
+{
+  "data-root": "/mnt/var/lib/docker",
+  "storage-driver": "overlay2",
+  "ipv6": true,
+  "fixed-cidr-v6": "fd15:4ba5:5a2b:100a::/64",
+  "icc": false,
+  "iptables": true
+}
+EOF


### PR DESCRIPTION
- enable 80-ephemeral-disks.sh script, to start making use of nvme drives
- ensure /home, /mnt/generic-worker/caches, /mnt/generic-worker/downloads and /mnt/var/lib/docker are backed by fast drives if present
- configure docker to enable ipv6, disable inter-container communication, and use /mnt/var/lib/docker for storage