### PR TITLE
Add missing #! to /usr/local/bin/configure-generic-worker-disks

### DIFF
--- a/scripts/linux/common/80-ephemeral-disks.sh
+++ b/scripts/linux/common/80-ephemeral-disks.sh
@@ -5,6 +5,7 @@ set -exv
 disk_setup_script="/usr/local/bin/configure-generic-worker-disks"
 
 cat << EOF > "${disk_setup_script}"
+#!/bin/sh
 # Main script logic
 if mount | grep "instance_storage"; then
     echo "/mnt is already using an nvme0n* device."


### PR DESCRIPTION
Fixes failures with `generic-worker-disk-setup.service: Failed to execute
/usr/local/bin/configure-generic-worker-disks: Exec format error`