### PR TITLE
chore: bump ubuntu 24.04 headless to taskcluster 83.4.0

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 81.0.3
+  taskcluster_version: 83.4.0
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-amd64-gui"


### PR DESCRIPTION
This picks up the new `volume` artifact type (https://github.com/taskcluster/taskcluster/issues/7594) and OOM monitoring (https://github.com/taskcluster/taskcluster/issues/6464).