### PR TITLE
chore: bump ubuntu 24.04 headless image to taskcluster 83.5.1

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 83.4.0
+  taskcluster_version: 83.5.1
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
This is to pick up https://github.com/taskcluster/taskcluster/pull/7627 for debugging purposes.