### PR TITLE
chore: bump ubuntu headless image to taskcluster 84.0.0

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 83.8.0
+  taskcluster_version: 84.0.0
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
To pick up https://github.com/taskcluster/taskcluster/pull/7723, which should fix https://github.com/mozilla/translations/issues/1117.