### PR TITLE
chore: update taskcluster to 84.0.1 on headless 24.04 image

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 84.0.0
+  taskcluster_version: 84.0.1
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1967254