### PR TITLE
fix: configure nvidia gpus for alpha images

### DIFF
--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -255,6 +255,7 @@ build {
       "${path.cwd}/scripts/linux/common/aslr.sh",
       "${path.cwd}/scripts/linux/common/docker-config.sh",
       "${path.cwd}/scripts/linux/common/ephemeral-disks.sh",
+      "${path.cwd}/scripts/linux/common/configure-nvidia-gpus.sh",
       "${path.cwd}/scripts/linux/common/userns.sh",
       "${path.cwd}/scripts/linux/common/v4l2loopback.sh"
     ]
@@ -487,6 +488,7 @@ build {
       "${path.cwd}/scripts/linux/common/aslr.sh",
       "${path.cwd}/scripts/linux/common/docker-config.sh",
       "${path.cwd}/scripts/linux/common/ephemeral-disks.sh",
+      "${path.cwd}/scripts/linux/common/configure-nvidia-gpus.sh",
       "${path.cwd}/scripts/linux/common/userns.sh",
       "${path.cwd}/scripts/linux/common/v4l2loopback.sh"
     ]


### PR DESCRIPTION
Follow up to https://github.com/mozilla-platform-ops/worker-images/pull/318.

As the `alpha-tc` image has proven to work well, I think it's safe to bring these changes up to `alpha`.