### PR TITLE
linux: disable apt-daily-upgrade.timer systemd unit

### DIFF
--- a/scripts/linux/taskcluster/bootstrap.sh
+++ b/scripts/linux/taskcluster/bootstrap.sh
@@ -169,6 +169,7 @@ retry apt-get install -y linux-modules-extra-$(uname -r)
 
 # avoid unnecessary shutdowns during worker startups
 systemctl disable unattended-upgrades
+systemctl disable apt-daily-upgrade.timer
 
 end_time="$(date '+%s')"
 echo "UserData execution took: $(($end_time - $start_time)) seconds"


### PR DESCRIPTION
We don't want the system applying updates, let alone when it's running tasks.