### PR TITLE
chore: bump tc versions to 84.2.0

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-arm64-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-arm64-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-central1-a
 vm:
   disk_size: 60
-  taskcluster_version: 83.4.0
+  taskcluster_version: 84.2.0
   tc_arch: ARM64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-arm64-headless"

--- a/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 83.4.0
+  taskcluster_version: 84.2.0
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-amd64-gui"

--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 84.0.1
+  taskcluster_version: 84.2.0
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
Picks up latest OOM killer tweaks/improvements in https://docs.taskcluster.net/docs/changelog?version=v84.2.0.