### PR TITLE
ci: stop creating decision tasks for push / pull-request events

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -105,8 +105,6 @@ tasks:
               in:
                   $if: >
                       tasks_for in ["action", "pr-action", "cron"]
-                      || (tasks_for == "github-push" && short_head_ref == "main")
-                      || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
                       || (isPullRequest && issueCommentAction in ["created", "edited"])
                   then:
                       taskId: {$if: 'tasks_for != "action" && tasks_for != "pr-action"', then: '${ownTaskId}'}


### PR DESCRIPTION
We aren't running any tasks in either place, so no point in creating a decision task.