### PR TITLE
ci: add treeherder-symbol to cron target

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -7,4 +7,5 @@ jobs:
       job:
           type: decision-task
           target-tasks-method: integration
+          treeherder-symbol: run-integration-tests
       when: []  # never (hook only)


### PR DESCRIPTION
Even though worker-images isn't on treeherder, it's required by the schema. We should fix the schema to not require this, but for now let's just satisfy it.