### PR TITLE
ci: hook cron input to a custom 'images' parameter

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -228,6 +228,9 @@ tasks:
                                             ACTION_TASK_ID: {$json: {$eval: 'taskId'}}  # taskId of the target task (JSON-encoded)
                                             ACTION_INPUT: {$json: {$eval: 'input'}}
                                             ACTION_CALLBACK: '${action.cb_name}'
+                                      - $if: 'tasks_for == "cron" && cron["input"]'
+                                        then:
+                                            DEPLOY_IMAGES: {$json: {$eval: cron.input}}
 
                               cache:
                                   "${trustDomain}-project-${project}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts

--- a/taskcluster/test/params/cron-run-integration-tests.yml
+++ b/taskcluster/test/params/cron-run-integration-tests.yml
@@ -15,6 +15,8 @@ head_ref: ahal/push-wpysxwompoxz
 head_repository: https://github.com/ahal/worker-images
 head_rev: 650f54ae5f42d77edab5acbeb3ed671ba4ff196b
 head_tag: ''
+images:
+  - win11-64-24h2-alpha
 level: '1'
 moz_build_date: '20250709191218'
 next_version: null
@@ -26,5 +28,5 @@ pushdate: 0
 pushlog_id: '0'
 repository_type: git
 target_tasks_method: integration
-tasks_for: github-issue-comment
+tasks_for: cron
 version: null

--- a/taskcluster/worker_images_taskgraph/__init__.py
+++ b/taskcluster/worker_images_taskgraph/__init__.py
@@ -13,7 +13,7 @@ def register(graph_config):
     register_mozilla_taskgraph(graph_config)
 
     # Import sibling modules, triggering decorators in the process
-    _import_modules(["target", "optimize"])
+    _import_modules(["optimize", "parameters", "target"])
 
 
 def _import_modules(modules):

--- a/taskcluster/worker_images_taskgraph/optimize.py
+++ b/taskcluster/worker_images_taskgraph/optimize.py
@@ -23,47 +23,12 @@ def is_subpath(base: Path, target: Path) -> bool:
 @register_strategy("integration-test")
 class IntegrationTestStrategy(OptimizationStrategy):
 
-    @cache
-    def _get_image_resources(self):
-        resource_map = defaultdict(set)
-        config_dir = Path("config")
-        for path in config_dir.glob("*.yaml"):
-            config = load_yaml(path)
-            image_key = "sharedimage" if "sharedimage" in config else "image"
-            image_name = config.get(image_key, {}).get("image_name")
-            if not image_name:
-                # Unknown config format
-                continue
-
-            resources = resource_map[image_name]
-            resources.add(path)
-
-            if scripts := config.get("vm", {}).get("script_paths"):
-                resources.update(scripts)
-
-        return resource_map
-
-    @cache
-    def _modified_images(self, files_changed: frozenset[str]) -> set[str]:
-        resource_map = self._get_image_resources()
-
-        images = set()
-        for image, resources in resource_map.items():
-            for resource in resources:
-                if any(is_subpath(resource, Path(path)) for path in files_changed):
-                    images.add(image)
-                    break
-
-        return images
-
     def should_remove_task(self, task, params, _) -> bool:
         task_queue_id = f"{task.task['provisionerId']}/{task.task['workerType']}"
         pool_images = get_worker_pool_images().get(task_queue_id, set())
 
-        files_changed = frozenset(params["files_changed"])
-        modified_images = self._modified_images(files_changed)
-
-        if pool_images & modified_images:
+        images = params["images"] or set()
+        if pool_images & images:
             return False
 
         return True

--- a/taskcluster/worker_images_taskgraph/parameters.py
+++ b/taskcluster/worker_images_taskgraph/parameters.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import os
+
+from taskgraph.parameters import extend_parameters_schema
+from voluptuous import Any, Required
+
+
+def get_defaults(repo_root):
+    return {
+        "images": None,
+    }
+
+
+extend_parameters_schema(
+    {
+        Required("images"): Any(None, list[str]),
+    },
+    defaults_fn=get_defaults,
+)
+
+
+def get_decision_parameters(graph_config, parameters):
+    if images := os.environ.get("DEPLOY_IMAGES"):
+        parameters["images"] = json.loads(images)


### PR DESCRIPTION
This parameter will denote which images are being deployed, which can be used by the optimization phase to determine which integration tests to run.