### PR TITLE
ci: register custom decision parameter properly

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -5,6 +5,7 @@ task-priority: low
 taskgraph:
   register: worker_images_taskgraph:register
   cached-task-prefix: "relops.v2.worker-images"
+  decision-parameters: 'worker_images_taskgraph.parameters:get_decision_parameters'
   repositories:
     worker_images:
       name: "worker-images"

--- a/taskcluster/worker_images_taskgraph/__init__.py
+++ b/taskcluster/worker_images_taskgraph/__init__.py
@@ -13,7 +13,7 @@ def register(graph_config):
     register_mozilla_taskgraph(graph_config)
 
     # Import sibling modules, triggering decorators in the process
-    _import_modules(["optimize", "parameters", "target"])
+    _import_modules(["optimize", "target"])
 
 
 def _import_modules(modules):


### PR DESCRIPTION
This function requires a special key in config.yml, and doesn't rely on decorator registration.