### PR TITLE
chore: bump ubuntu alpha images to tc v90.0.2

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-arm64-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-arm64-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-central1-a
 vm:
   disk_size: 60
-  taskcluster_version: 87.1.2
+  taskcluster_version: 90.0.2
   tc_arch: ARM64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-arm64-headless"

--- a/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 87.1.2
+  taskcluster_version: 90.0.2
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-amd64-gui"

--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 87.1.2
+  taskcluster_version: 90.0.2
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
Picks up a handful of d2g upgrades among other things https://docs.taskcluster.net/docs/changelog?from=v87.1.3&to=v90.0.2