### PR TITLE
chore(fix): skip if no launchConfig in pool config

### DIFF
--- a/taskcluster/worker_images_taskgraph/util/fxci.py
+++ b/taskcluster/worker_images_taskgraph/util/fxci.py
@@ -22,6 +22,10 @@ def get_worker_pool_images() -> dict[str, set[str]]:
     for pool in data["workerPools"]:
         assert isinstance(pool, dict)
 
+        # Skip pools that don't have launchConfigs
+        if "launchConfigs" not in pool["config"]:
+            continue
+
         for lc in pool["config"]["launchConfigs"]:
             image = None
             if disks := lc.get("disks"):


### PR DESCRIPTION
Running into error while triggering hook

```
[task 2025-09-24T16:15:29.263+00:00]   File "/builds/worker/checkouts/src/taskcluster/worker_images_taskgraph/transforms/integration_test.py", line 32, in add_optimization
[task 2025-09-24T16:15:29.263+00:00]     for task in tasks:
[task 2025-09-24T16:15:29.263+00:00]   File "/builds/worker/checkouts/src/taskcluster/worker_images_taskgraph/transforms/integration_test.py", line 13, in change_worker_pool_to_alpha
[task 2025-09-24T16:15:29.263+00:00]     pools = get_worker_pool_images().keys()
[task 2025-09-24T16:15:29.263+00:00]             ^^^^^^^^^^^^^^^^^^^^^^^^
[task 2025-09-24T16:15:29.263+00:00]   File "/builds/worker/checkouts/src/taskcluster/worker_images_taskgraph/util/fxci.py", line 25, in get_worker_pool_images
[task 2025-09-24T16:15:29.263+00:00]     for lc in pool["config"]["launchConfigs"]:
[task 2025-09-24T16:15:29.263+00:00]               ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
[task 2025-09-24T16:15:29.263+00:00] KeyError: 'launchConfigs'
```