### PR TITLE
chore: bump ubuntu alpha images to tc v90.0.4

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-arm64-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-arm64-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-central1-a
 vm:
   disk_size: 60
-  taskcluster_version: 90.0.3
+  taskcluster_version: 90.0.4
   tc_arch: ARM64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-arm64-headless"

--- a/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 90.0.3
+  taskcluster_version: 90.0.4
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-amd64-gui"

--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 90.0.3
+  taskcluster_version: 90.0.4
   tc_arch: AMD64
   script_paths: 
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
Picks up a few D2G fixes https://docs.taskcluster.net/docs/changelog?version=v90.0.4