### PR TITLE
Retry packer builds on transient WinRM failures

### DIFF
--- a/.github/workflows/DEV-sig-nontrusted.yml
+++ b/.github/workflows/DEV-sig-nontrusted.yml
@@ -77,7 +77,20 @@ jobs:
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI }}"
           }
-          New-AzSharedWorkerImage @Vars
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Packer attempt $attempt of $maxAttempts"
+            New-AzSharedWorkerImage @Vars
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              Write-Host "::error ::Packer failed after $maxAttempts attempts"
+              exit 1
+            }
+            Write-Host "::warning ::Packer failed (attempt $attempt, exit code $LASTEXITCODE). Retrying in 30 seconds..."
+            Start-Sleep -Seconds 30
+          }
           "sharedimageversion=$ENV:PKR_VAR_sharedimage_version" >> $env:GITHUB_ENV
       - name: Upload Release Notes Artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f

--- a/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
+++ b/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
@@ -95,7 +95,21 @@ jobs:
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI }}"
           }
-          New-AzSharedWorkerImage @Vars
+
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Packer attempt $attempt of $maxAttempts"
+            New-AzSharedWorkerImage @Vars
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              Write-Host "::error ::Packer failed after $maxAttempts attempts"
+              exit 1
+            }
+            Write-Host "::warning ::Packer failed (attempt $attempt, exit code $LASTEXITCODE). Retrying in 30 seconds..."
+            Start-Sleep -Seconds 30
+          }
           "sharedimageversion=$ENV:PKR_VAR_sharedimage_version" >> $env:GITHUB_ENV
       - name: Upload Release Notes Artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f

--- a/.github/workflows/sig-monitor-nontrusted.yml
+++ b/.github/workflows/sig-monitor-nontrusted.yml
@@ -77,7 +77,20 @@ jobs:
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI }}"
           }
-          New-AzSharedWorkerImage @Vars
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Packer attempt $attempt of $maxAttempts"
+            New-AzSharedWorkerImage @Vars
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              Write-Host "::error ::Packer failed after $maxAttempts attempts"
+              exit 1
+            }
+            Write-Host "::warning ::Packer failed (attempt $attempt, exit code $LASTEXITCODE). Retrying in 30 seconds..."
+            Start-Sleep -Seconds 30
+          }
           "sharedimageversion=$ENV:PKR_VAR_sharedimage_version" >> $env:GITHUB_ENV
       - name: Upload Release Notes Artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f

--- a/.github/workflows/sig-nontrusted.yml
+++ b/.github/workflows/sig-nontrusted.yml
@@ -74,7 +74,20 @@ jobs:
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI }}"
           }
-          New-AzSharedWorkerImage @Vars
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Packer attempt $attempt of $maxAttempts"
+            New-AzSharedWorkerImage @Vars
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              Write-Host "::error ::Packer failed after $maxAttempts attempts"
+              exit 1
+            }
+            Write-Host "::warning ::Packer failed (attempt $attempt, exit code $LASTEXITCODE). Retrying in 30 seconds..."
+            Start-Sleep -Seconds 30
+          }
           "sharedimageversion=$ENV:PKR_VAR_sharedimage_version" >> $env:GITHUB_ENV
       - name: Upload Release Notes Artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f

--- a/.github/workflows/sig-trusted.yml
+++ b/.github/workflows/sig-trusted.yml
@@ -62,7 +62,20 @@ jobs:
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI_TRUSTED }}"
           }
-          New-AzSharedWorkerImage @Vars
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Packer attempt $attempt of $maxAttempts"
+            New-AzSharedWorkerImage @Vars
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              Write-Host "::error ::Packer failed after $maxAttempts attempts"
+              exit 1
+            }
+            Write-Host "::warning ::Packer failed (attempt $attempt, exit code $LASTEXITCODE). Retrying in 30 seconds..."
+            Start-Sleep -Seconds 30
+          }
           "sharedimageversion=$ENV:PKR_VAR_sharedimage_version" >> $env:GITHUB_ENV
       - name: Upload Release Notes Artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f


### PR DESCRIPTION
## Summary
- Packer builds occasionally fail with transient WinRM upload errors (`Error removing temporary file ... received error response`), wasting 12+ minute builds and blocking downstream SBOM/os-integration jobs.
- Added a retry loop (up to 3 attempts, 30s delay between retries) around `New-AzSharedWorkerImage` in all SIG workflows.
- Uses `$LASTEXITCODE` to detect failure since `packer build` is a native command that doesn't throw PowerShell exceptions.

**Workflows updated:**
- `sig-FXCI-nontrusted-parallel-build-alpha.yml`
- `sig-nontrusted.yml`
- `sig-trusted.yml`
- `sig-monitor-nontrusted.yml`
- `DEV-sig-nontrusted.yml`

**Example failure:** https://github.com/mozilla-platform-ops/worker-images/actions/runs/21991206612/job/63538558857

## Test plan
- [ ] Trigger an alpha build and confirm retry logging appears on attempt 1 (`Packer attempt 1 of 3`)
- [ ] If a transient failure occurs, verify it retries automatically instead of failing the workflow