### PR TITLE
[RELOPS-2218] Add NVIDIA A10 GPU driver test for win11-64-25h2

### DIFF
--- a/config/win11-64-25h2.yaml
+++ b/config/win11-64-25h2.yaml
@@ -45,6 +45,6 @@ tests:
   - mozilla_build.tests.ps1
   - mozilla_maintenance_service.tests.ps1
   - windows_worker_runner.tests.ps1
-  - gpu_drivers.tests.ps1
+  - gpu_drivers_a10.tests.ps1
   - mercurial.tests.ps1
   - microsoft_wptx64.tests.ps1

--- a/tests/win/gpu_drivers_a10.tests.ps1
+++ b/tests/win/gpu_drivers_a10.tests.ps1
@@ -1,0 +1,12 @@
+Describe "Nvidia A10 GPU Drivers Downloaded" {
+    BeforeDiscovery {
+        $Hiera = $Data.Hiera
+    }
+
+    BeforeAll {
+        $GPU = $Hiera.windows.gpu_a10.name
+    }
+    It "Nvidia A10 GPU Drivers are downloaded" {
+        Test-Path "$systemdrive\Windows\Temp\$($GPU).exe" | Should -Be $true
+    }
+}


### PR DESCRIPTION
## Summary

- Add `gpu_drivers_a10.tests.ps1` verifying the GRID 553.62 driver exe is downloaded for NVIDIA A10 workers
- Replace `gpu_drivers.tests.ps1` with `gpu_drivers_a10.tests.ps1` in `config/win11-64-25h2.yaml`

Win11 25H2 GPU workers run on `Standard_NV12ads_A10_v5` (NVIDIA A10, GRID 553.62). The existing `gpu_drivers.tests.ps1` checks for `windows.gpu.name` (the M60/538.15 driver). The new test checks `windows.gpu_a10.name` (553.62), matching the driver that `win116425h2azure` puppet role now downloads.

Companion ronin_puppet PR: mozilla-platform-ops/ronin_puppet#1079

Jira: [RELOPS-2218](https://mozilla-hub.atlassian.net/browse/RELOPS-2218)

## Test plan

- [ ] Rebuild `win11-64-25h2` image and confirm `gpu_drivers_a10.tests.ps1` passes (553.62 exe present in `C:\Windows\Temp\`)
- [ ] Confirm `win11-64-24h2` image build is unaffected (still uses `gpu_drivers.tests.ps1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)