### PR TITLE
Use VM mode for Azure image Sysprep

### DIFF
--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -493,7 +493,9 @@ build {
       "Set-ItemProperty -Path 'HKLM:\\SOFTWARE\\Mozilla\\ronin_puppet' -Name hand_off_ready -Type string -Value yes;",
       "Write-host '=== Azure image build completed successfully ===';",
       "Write-host '=== Generalising the image ... ===';",
-      "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /generalize /oobe /quit;",
+      "$sysprepUnattend = Join-Path $env:SystemRoot 'System32\\Sysprep\\unattend.xml';",
+      "Remove-Item -Path $sysprepUnattend -Force -ErrorAction SilentlyContinue;",
+      "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit;",
       "while ($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 15 } else { break } }"
     ]
   }


### PR DESCRIPTION
## Summary
- remove Sysprep unattend.xml before generalizing Azure Windows images
- run Sysprep with /mode:vm and /quiet to match Microsoft Packer guidance and runner-images behavior

## Validation
- packer fmt azure.pkr.hcl
- packer validate -syntax-only azure.pkr.hcl
- git diff --check