### PR TITLE
Replicate win11-64-25h2 to canadaeast and southeastasia

### DIFF
--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -197,6 +197,7 @@ variable "replication_regions" {
   description = "List of Azure regions to replicate the shared image to"
   default = [
     "canadacentral",
+    "canadaeast",
     "centralindia",
     "eastus",
     "eastus2",
@@ -204,6 +205,7 @@ variable "replication_regions" {
     "northeurope",
     "southindia",
     "southcentralus",
+    "southeastasia",
     "uksouth",
     "westus",
     "westus2",

--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -197,7 +197,6 @@ variable "replication_regions" {
   description = "List of Azure regions to replicate the shared image to"
   default = [
     "canadacentral",
-    "canadaeast",
     "centralindia",
     "eastus",
     "eastus2",
@@ -205,7 +204,6 @@ variable "replication_regions" {
     "northeurope",
     "southindia",
     "southcentralus",
-    "southeastasia",
     "uksouth",
     "westus",
     "westus2",

--- a/config/win11-64-25h2.yaml
+++ b/config/win11-64-25h2.yaml
@@ -11,6 +11,21 @@ sharedimage:
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"
+  locations:
+    - canadacentral
+    - canadaeast
+    - centralindia
+    - eastus
+    - eastus2
+    - northcentralus
+    - northeurope
+    - southindia
+    - southcentralus
+    - southeastasia
+    - uksouth
+    - westus
+    - westus2
+    - westus3
 vm:
   puppet_version: "default"
   git_version: "default"


### PR DESCRIPTION
Adds an explicit \`azure.locations\` override to \`config/win11-64-25h2.yaml\` so the production Windows 11 25H2 shared image gets replicated to two new Azure regions:

- \`canadaeast\`
- \`southeastasia\`

\`uksouth\` is already in the global packer default, so no addition needed there.

## Why scoped to one image

Companion to [mozilla-releng/fxci-config#946](https://github.com/mozilla-releng/fxci-config/pull/946), which adds canada-east, uk-south, and southeast-asia to the \`gecko-t/win11-64-25h2\` worker pool. Only this image needs the new replicas right now — other Windows images (gecko-1/2, comm-t, enterprise-*, nss-*, mozilla-1, taskgraph-t) are not changing their pool location lists, so replicating their images to canadaeast/southeastasia would burn storage with no consumer.

An earlier commit on this branch updated the global default in \`azure.pkr.hcl\`; that has been reverted. The per-image override is the narrower, lower-blast-radius approach.

## How the override works

\`bin/WorkerImages/Public/New-AzSharedWorkerImage.ps1:122-130\` reads \`azure.locations\` from the per-image yaml and sets \`PKR_VAR_replication_regions\` from it, overriding the default declared in \`azure.pkr.hcl\`. The list contains the 12 regions from today's default plus \`canadaeast\` and \`southeastasia\`, so no existing replicas are dropped.

## Region selection

Both new regions sit in Azure's 0-5% bucket of the 28-day \`Standard_F8s_v2\` Spot eviction history (\`AzureResourceGraph.SpotResources\`) and are below the current pool's median Spot Windows price (canadaeast \$0.1366/hr, southeastasia \$0.1404/hr). See fxci-config#946 for the full cost+eviction analysis.

## Plan

@jmoss will trigger a win11-64-25h2 image build manually after merge to push the new replicas into canadaeast and southeastasia. Companion PR [mozilla-platform-ops/relops_infra_as_code#293](https://github.com/mozilla-platform-ops/relops_infra_as_code/pull/293) provisions the per-region rg/vnet/subnet/nsg/storage in those regions for gecko-t.