### PR TITLE
Pin image_version per config instead of via shared default

### DIFF
--- a/config/trusted-win11-a64-24h2-builder.yaml
+++ b/config/trusted-win11-a64-24h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "trusted_win11_a64_24h2_builder"
   image_name: "trusted_win11_a64_24h2_builder"
-  image_version: "default"
+  image_version: "1.3.0"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/trusted-win11-a64-25h2-builder.yaml
+++ b/config/trusted-win11-a64-25h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "trusted_win11_a64_25h2_builder"
   image_name: "trusted_win11_a64_25h2_builder"
-  image_version: "default"
+  image_version: "1.0.1"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/trusted-win2022-64-2009.yaml
+++ b/config/trusted-win2022-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "trusted_win2022_64_2009"
   image_name: "trusted_win2022_64_2009"
-  image_version: "default"
+  image_version: "1.3.0"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win10-64-2009.yaml
+++ b/config/win10-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win10_64_2009"
   image_name: "win10_64_2009"
-  image_version: "default"
+  image_version: "1.3.0"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-64-2009.yaml
+++ b/config/win11-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_64_2009"
   image_name: "win11_64_2009"
-  image_version: "default"
+  image_version: "1.3.0"
 azure:
   managed_image_resource_group_name: rg-packer-worker-images
   managed_image_storage_account_type: Standard_LRS

--- a/config/win11-64-24h2.yaml
+++ b/config/win11-64-24h2.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_64_24h2"
   image_name: "win11_64_24h2"
-  image_version: "default"
+  image_version: "1.3.0"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-a64-24h2-builder.yaml
+++ b/config/win11-a64-24h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_24h2_builder"
   image_name: "win11_a64_24h2_builder"
-  image_version: "default"
+  image_version: "1.3.0"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-a64-24h2-tester.yaml
+++ b/config/win11-a64-24h2-tester.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_24h2_tester"
   image_name: "win11_a64_24h2_tester"
-  image_version: "default"
+  image_version: "1.3.0"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win2022-64-2009.yaml
+++ b/config/win2022-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win2022_64_2009"
   image_name: "win2022_64_2009"
-  image_version: "default"
+  image_version: "1.3.0"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/windows_production_defaults.yaml
+++ b/config/windows_production_defaults.yaml
@@ -2,8 +2,6 @@
 azure:
   managed_image_resource_group_name: rg-packer-worker-images
   managed_image_storage_account_type: Standard_LRS
-sharedimage:
-  image_version: 1.3.0
 vm:
   puppet_version: 8.10.0
   git_version: 2.53.0


### PR DESCRIPTION
## Summary
- Removes `sharedimage.image_version` from `config/windows_production_defaults.yaml`. Each per-image config now owns its own version.
- The shared `1.3.0` default was silently inherited by every config that set `image_version: \"default\"`, including `trusted-win11-a64-25h2-builder.yaml` — which meant the 25h2 trusted builder was on the same version track as 24h2 despite 25h2 being on a separate release cadence.
- Pins `trusted-win11-a64-25h2-builder.yaml` to `1.0.1`, aligning it with the other 25h2 prod configs and stepping one ahead of fxci-config's currently-deployed `1.0.0` for that gallery.
- Pins all other previously-`\"default\"` configs (24h2 prod, win10-2009, win11-2009, win2022-2009, and their trusted variants) to `1.3.0` to preserve current build behavior.

## Track summary after this change
| Track | Version |
|---|---|
| 24h2 prod (incl. trusted-24h2 builder) | `1.3.0` |
| 25h2 prod (untrusted) | `1.0.1` |
| 25h2 trusted builder | `1.0.1` |
| win10-2009 / win11-2009 / win2022-2009 (incl. trusted-2022) | `1.3.0` |
| All alphas | unchanged (already explicit) |

## Why
A single shared default across OS tracks with independent cadences was misleading: the 25h2 trusted builder picked up `1.3.0` purely because no one set the field on it. Going forward, version bumps are per-track edits, which matches reality.

## Test plan
- [ ] Trigger `sig-FXCI-nontrusted-parallel-build.yml` (manually or as part of the next release) and confirm each prod image builds at the version pinned in its config.
- [ ] Trigger `sig-trusted.yml` for `trusted-win11-a64-25h2-builder` and confirm the resulting SIG version is `1.0.1` (not `1.3.0`).
- [ ] Confirm OS integration tests still pass for the 24h2 and 25h2 testers (no functional change expected — version values are the only thing that moved).