### PR TITLE
Fix Azure OIDC env handling

### DIFF
--- a/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
+++ b/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
@@ -90,8 +90,8 @@ jobs:
             github_token = "${{ secrets.GITHUB_TOKEN }}"
             Key = '${{ matrix.config }}'
             Client_ID = "${{ secrets.AZURE_CLIENT_ID_FXCI }}"
-            oidc_request_url = "${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}"
-            oidc_request_token = "${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}"
+            oidc_request_url = $env:ACTIONS_ID_TOKEN_REQUEST_URL
+            oidc_request_token = $env:ACTIONS_ID_TOKEN_REQUEST_TOKEN
             Subscription_ID = "${{ secrets.AZURE_SUBSCRIPTION_ID_UNTRUSTED }}"
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI }}"

--- a/.github/workflows/sig-FXCI-parallel-build.yml
+++ b/.github/workflows/sig-FXCI-parallel-build.yml
@@ -63,8 +63,6 @@ jobs:
           CLIENT_ID: ${{ secrets[matrix.client_id_secret] }}
           CONFIG: ${{ matrix.config }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OIDC_REQUEST_TOKEN: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
-          OIDC_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
           SUBSCRIPTION_ID: ${{ secrets[matrix.subscription_id_secret] }}
           TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         run: ./ci/build-azure-shared-worker-image.ps1

--- a/.github/workflows/sig-nontrusted.yml
+++ b/.github/workflows/sig-nontrusted.yml
@@ -74,8 +74,8 @@ jobs:
             github_token = "${{ secrets.GITHUB_TOKEN }}"
             Key = '${{ github.event.inputs.config }}'
             Client_ID = "${{ secrets.AZURE_CLIENT_ID_FXCI }}"
-            oidc_request_url = "${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}"
-            oidc_request_token = "${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}"
+            oidc_request_url = $env:ACTIONS_ID_TOKEN_REQUEST_URL
+            oidc_request_token = $env:ACTIONS_ID_TOKEN_REQUEST_TOKEN
             Subscription_ID = "${{ secrets.AZURE_SUBSCRIPTION_ID_UNTRUSTED }}"
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI }}"

--- a/.github/workflows/sig-trusted.yml
+++ b/.github/workflows/sig-trusted.yml
@@ -57,8 +57,8 @@ jobs:
             github_token = "${{ secrets.GITHUB_TOKEN }}"
             Key = '${{ github.event.inputs.config }}'
             Client_ID = "${{ secrets.AZURE_CLIENT_ID_FXCI_TRUSTED }}"
-            oidc_request_url = "${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}"
-            oidc_request_token = "${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}"
+            oidc_request_url = $env:ACTIONS_ID_TOKEN_REQUEST_URL
+            oidc_request_token = $env:ACTIONS_ID_TOKEN_REQUEST_TOKEN
             Subscription_ID = "${{ secrets.AZURE_SUBSCRIPTION_ID_TRUSTED }}"
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI_TRUSTED }}"

--- a/ci/build-azure-shared-worker-image.ps1
+++ b/ci/build-azure-shared-worker-image.ps1
@@ -1,6 +1,14 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+if (-not [Environment]::GetEnvironmentVariable("OIDC_REQUEST_URL")) {
+    $env:OIDC_REQUEST_URL = [Environment]::GetEnvironmentVariable("ACTIONS_ID_TOKEN_REQUEST_URL")
+}
+
+if (-not [Environment]::GetEnvironmentVariable("OIDC_REQUEST_TOKEN")) {
+    $env:OIDC_REQUEST_TOKEN = [Environment]::GetEnvironmentVariable("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+}
+
 $requiredVars = @(
     "CONFIG",
     "GITHUB_TOKEN",


### PR DESCRIPTION
## Summary
- Read GitHub Actions OIDC request values from runtime PowerShell environment variables instead of the workflow `env` expression context.
- Make `ci/build-azure-shared-worker-image.ps1` fall back to `ACTIONS_ID_TOKEN_REQUEST_*` when `OIDC_REQUEST_*` is not explicitly set.
- Apply the same runtime env pattern to the other FXCI Azure workflows.

## Context
Run https://github.com/mozilla-platform-ops/worker-images/actions/runs/25058303876 failed every Packer job because `OIDC_REQUEST_URL` and `OIDC_REQUEST_TOKEN` were empty.

## Validation
- `git diff --check`
- `actionlint .github/workflows/sig-FXCI-parallel-build.yml .github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml .github/workflows/sig-nontrusted.yml .github/workflows/sig-trusted.yml`
- `pwsh -NoLogo -NoProfile -Command ... ParseFile(...)`