### PR TITLE
RELOPS-2344: Pool reorganization based on CPU performance audit

### DIFF
--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -53,7 +53,8 @@ pools:
     hash: "99589a8"
     secret_date: "01-20-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
-    nodes: []
+    nodes:
+    - nuc13-989 # temp fake node — placeholder to prevent scripting failures on empty pool
   - name: "win11-64-24h2-hw-perf-debug"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -66,7 +67,8 @@ pools:
     hash: "90c5aec"
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
-    nodes: []
+    nodes:
+    - nuc13-989 # temp fake node — placeholder to prevent scripting failures on empty pool
   - name: "win11-64-24h2-hw-alpha"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -80,7 +82,8 @@ pools:
     hash: "f11339d"
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
-    nodes: []
+    nodes:
+    - nuc13-989 # temp fake node — placeholder to prevent scripting failures on empty pool
   - name: "win11-64-24h2-hw-perf-sheriff"
     openvox_version: "8.19.2"
     puppet_version: "8.10.0"

--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -54,7 +54,7 @@ pools:
     secret_date: "01-20-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
-    - nuc13-989 # temp fake node — placeholder to prevent scripting failures on empty pool
+    - nuc13-901 # temp fake node — placeholder to prevent scripting failures on empty pool
   - name: "win11-64-24h2-hw-perf-debug"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -68,7 +68,7 @@ pools:
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
-    - nuc13-989 # temp fake node — placeholder to prevent scripting failures on empty pool
+    - nuc13-902 # temp fake node — placeholder to prevent scripting failures on empty pool
   - name: "win11-64-24h2-hw-alpha"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -83,7 +83,7 @@ pools:
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
-    - nuc13-989 # temp fake node — placeholder to prevent scripting failures on empty pool
+    - nuc13-903 # temp fake node — placeholder to prevent scripting failures on empty pool
   - name: "win11-64-24h2-hw-perf-sheriff"
     openvox_version: "8.19.2"
     puppet_version: "8.10.0"

--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -53,10 +53,7 @@ pools:
     hash: "99589a8"
     secret_date: "01-20-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
-    nodes:
-    - nuc13-001
-    - nuc13-002
-    - nuc13-003
+    nodes: []
   - name: "win11-64-24h2-hw-perf-debug"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -69,14 +66,7 @@ pools:
     hash: "90c5aec"
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
-    nodes:
-    - nuc13-004
-    - nuc13-005
-    - nuc13-066
-    - nuc13-108
-    - nuc13-131
-    - nuc13-159
-    - nuc13-160
+    nodes: []
   - name: "win11-64-24h2-hw-alpha"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -90,31 +80,7 @@ pools:
     hash: "f11339d"
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
-    nodes:
-    - nuc13-006
-    - nuc13-007
-    - nuc13-008
-    - nuc13-009
-    - nuc13-010
-    - nuc13-011
-    - nuc13-012
-    - nuc13-013
-    - nuc13-014
-    - nuc13-015
-    - nuc13-016
-    - nuc13-017
-    - nuc13-018
-    - nuc13-019
-    - nuc13-020
-    - nuc13-022
-    - nuc13-023
-    - nuc13-024
-    - nuc13-025
-    - nuc13-026
-    - nuc13-027
-    - nuc13-028
-    - nuc13-029
-    - nuc13-030
+    nodes: []
   - name: "win11-64-24h2-hw-perf-sheriff"
     openvox_version: "8.19.2"
     puppet_version: "8.10.0"
@@ -142,6 +108,35 @@ pools:
     secret_date: "02-24-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
+    - nuc13-001
+    - nuc13-002
+    - nuc13-003
+    - nuc13-004
+    - nuc13-005
+    - nuc13-006
+    - nuc13-007
+    - nuc13-008
+    - nuc13-009
+    - nuc13-010
+    - nuc13-011
+    - nuc13-012
+    - nuc13-013
+    - nuc13-014
+    - nuc13-015
+    - nuc13-016
+    - nuc13-017
+    - nuc13-018
+    - nuc13-019
+    - nuc13-020
+    - nuc13-022
+    - nuc13-023
+    - nuc13-024
+    - nuc13-025
+    - nuc13-026
+    - nuc13-027
+    - nuc13-028
+    - nuc13-029
+    - nuc13-030
     - nuc13-031
     - nuc13-032
     - nuc13-033
@@ -177,6 +172,7 @@ pools:
     - nuc13-063
     - nuc13-064
     - nuc13-065
+    - nuc13-066
     - nuc13-067
     - nuc13-068
     - nuc13-069
@@ -217,6 +213,7 @@ pools:
     - nuc13-104
     - nuc13-105
     - nuc13-106
+    - nuc13-108
     - nuc13-109
     - nuc13-110
     - nuc13-111
@@ -238,6 +235,7 @@ pools:
     - nuc13-128
     - nuc13-129
     - nuc13-130
+    - nuc13-131
     - nuc13-132
     - nuc13-133
     - nuc13-134
@@ -265,6 +263,8 @@ pools:
     - nuc13-156
     - nuc13-157
     - nuc13-158
+    - nuc13-159
+    - nuc13-160
 defaults:
   NV_domain: "mdc1.mozilla.com"
 Validate:


### PR DESCRIPTION
## Summary

- Moves all nodes from `win11-64-24h2-hw-alpha`, `win11-64-24h2-hw-relops1213`, and `win11-64-24h2-hw-perf-debug` into the main `win11-64-24h2-hw` pool
- Source pools are cleared (`nodes: []`) but retained as placeholders pending final naming decisions for the CPU-performance-based reorganization
- `win11-64-24h2-hw-perf-sheriff` (nuc13-021) is unchanged

## Context

Following fleet-wide CPU stress testing (2026-04-22/23) and 7-day Event 37 audit conducted as part of [RELOPS-2323](https://mozilla-hub.atlassian.net/browse/RELOPS-2323), the alpha/debug pools are being consolidated into the main production pool. Further pool splitting based on CPU performance classification is tracked in [RELOPS-2344](https://mozilla-hub.atlassian.net/browse/RELOPS-2344).

## Node count changes

| Pool | Before | After |
|---|---|---|
| win11-64-24h2-hw (main) | 123 nodes | 157 nodes |
| win11-64-24h2-hw-alpha | 24 nodes | 0 (cleared) |
| win11-64-24h2-hw-relops1213 | 3 nodes | 0 (cleared) |
| win11-64-24h2-hw-perf-debug | 7 nodes | 0 (cleared) |

## Test plan
- [ ] Verify node count in win11-64-24h2-hw matches expected 157
- [ ] Confirm nuc13-021 remains only in win11-64-24h2-hw-perf-sheriff
- [ ] Confirm nuc13-107 and nuc13-112 remain only in Known-BAD (not added to any pool)