### PR TITLE
RELOPS-2344: Remove down and questionable nodes from main pool

### DIFF
--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -41,6 +41,8 @@ pools:
     nodes:
     - t-nuc12-002
     - t-nuc12-003
+  # Down / offline nodes — bad PSU, persistent SSH failures, or awaiting hardware replacement.
+  # These nodes are not expected to run production work. Pool name is a placeholder pending final naming.
   - name: "win11-64-24h2-hw-relops1213"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -88,6 +90,8 @@ pools:
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
     - nuc13-902 # temp fake node — placeholder to prevent scripting failures on empty pool
+  # Questionable nodes — CPU suppression confirmed or notable floor events detected in stress testing.
+  # Not cleared for high-priority CPU-intensive work. Pending PSU inspection/replacement.
   - name: "win11-64-24h2-hw-alpha"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -266,21 +270,21 @@ pools:
     - nuc13-152
     - nuc13-153
     - nuc13-160
-    - defaults:
-    - NV_domain:
-    - Validate:
-    - hw_class:
-    - "t-nuc12"
-    - "nuc13"
-    - Known-BAD:
-    - ##
-    - nuc13:
-    - ##
-    - ##
+defaults:
+  NV_domain: "mdc1.mozilla.com"
+Validate:
+    hw_class:
+        - "t-nuc12"
+        - "nuc13"
+Known-BAD:
+  ## Add comment comment above the name of the node
+  nuc13:
+    ## Dead.
+    ## https://mozilla-hub.atlassian.net/browse/RELOPS-1555?focusedCommentId=1076567
     - nuc13-112
-    - ##
-    - ##
+    ## TLS errors on PXE boot.
+    ## https://mozilla-hub.atlassian.net/browse/RELOPS-1555?focusedCommentId=1076567
     - nuc13-107
-    - ##
-    - ##
+    ## Dead
+    ## Different model as well
     - t-nuc12-001

--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -54,7 +54,26 @@ pools:
     secret_date: "01-20-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
-    - nuc13-901 # temp fake node — placeholder to prevent scripting failures on empty pool
+    - nuc13-024
+    - nuc13-035
+    - nuc13-036
+    - nuc13-045
+    - nuc13-059
+    - nuc13-060
+    - nuc13-061
+    - nuc13-068
+    - nuc13-070
+    - nuc13-075
+    - nuc13-096
+    - nuc13-124
+    - nuc13-130
+    - nuc13-132
+    - nuc13-149
+    - nuc13-150
+    - nuc13-154
+    - nuc13-155
+    - nuc13-156
+    - nuc13-157
   - name: "win11-64-24h2-hw-perf-debug"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -83,7 +102,27 @@ pools:
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
-    - nuc13-903 # temp fake node — placeholder to prevent scripting failures on empty pool
+    - nuc13-010
+    - nuc13-015
+    - nuc13-019
+    - nuc13-027
+    - nuc13-032
+    - nuc13-058
+    - nuc13-063
+    - nuc13-065
+    - nuc13-067
+    - nuc13-077
+    - nuc13-079
+    - nuc13-080
+    - nuc13-097
+    - nuc13-106
+    - nuc13-120
+    - nuc13-139
+    - nuc13-145
+    - nuc13-147
+    - nuc13-148
+    - nuc13-158
+    - nuc13-159
   - name: "win11-64-24h2-hw-perf-sheriff"
     openvox_version: "8.19.2"
     puppet_version: "8.10.0"
@@ -120,32 +159,24 @@ pools:
     - nuc13-007
     - nuc13-008
     - nuc13-009
-    - nuc13-010
     - nuc13-011
     - nuc13-012
     - nuc13-013
     - nuc13-014
-    - nuc13-015
     - nuc13-016
     - nuc13-017
     - nuc13-018
-    - nuc13-019
     - nuc13-020
     - nuc13-022
     - nuc13-023
-    - nuc13-024
     - nuc13-025
     - nuc13-026
-    - nuc13-027
     - nuc13-028
     - nuc13-029
     - nuc13-030
     - nuc13-031
-    - nuc13-032
     - nuc13-033
     - nuc13-034
-    - nuc13-035
-    - nuc13-036
     - nuc13-037
     - nuc13-038
     - nuc13-039
@@ -154,7 +185,6 @@ pools:
     - nuc13-042
     - nuc13-043
     - nuc13-044
-    - nuc13-045
     - nuc13-046
     - nuc13-047
     - nuc13-048
@@ -167,29 +197,16 @@ pools:
     - nuc13-055
     - nuc13-056
     - nuc13-057
-    - nuc13-058
-    - nuc13-059
-    - nuc13-060
-    - nuc13-061
     - nuc13-062
-    - nuc13-063
     - nuc13-064
-    - nuc13-065
     - nuc13-066
-    - nuc13-067
-    - nuc13-068
     - nuc13-069
-    - nuc13-070
     - nuc13-071
     - nuc13-072
     - nuc13-073
     - nuc13-074
-    - nuc13-075
     - nuc13-076
-    - nuc13-077
     - nuc13-078
-    - nuc13-079
-    - nuc13-080
     - nuc13-081
     - nuc13-082
     - nuc13-083
@@ -205,8 +222,6 @@ pools:
     - nuc13-093
     - nuc13-094
     - nuc13-095
-    - nuc13-096
-    - nuc13-097
     - nuc13-098
     - nuc13-099
     - nuc13-100
@@ -215,7 +230,6 @@ pools:
     - nuc13-103
     - nuc13-104
     - nuc13-105
-    - nuc13-106
     - nuc13-108
     - nuc13-109
     - nuc13-110
@@ -227,62 +241,46 @@ pools:
     - nuc13-117
     - nuc13-118
     - nuc13-119
-    - nuc13-120
     - nuc13-121
     - nuc13-122
     - nuc13-123
-    - nuc13-124
     - nuc13-125
     - nuc13-126
     - nuc13-127
     - nuc13-128
     - nuc13-129
-    - nuc13-130
     - nuc13-131
-    - nuc13-132
     - nuc13-133
     - nuc13-134
     - nuc13-135
     - nuc13-136
     - nuc13-137
     - nuc13-138
-    - nuc13-139
     - nuc13-140
     - nuc13-141
     - nuc13-142
     - nuc13-143
     - nuc13-144
-    - nuc13-145
     - nuc13-146
-    - nuc13-147
-    - nuc13-148
-    - nuc13-149
-    - nuc13-150
     - nuc13-151
     - nuc13-152
     - nuc13-153
-    - nuc13-154
-    - nuc13-155
-    - nuc13-156
-    - nuc13-157
-    - nuc13-158
-    - nuc13-159
     - nuc13-160
-defaults:
-  NV_domain: "mdc1.mozilla.com"
-Validate:
-    hw_class:
-        - "t-nuc12"
-        - "nuc13"
-Known-BAD:
-  ## Add comment comment above the name of the node
-  nuc13:
-    ## Dead.
-    ## https://mozilla-hub.atlassian.net/browse/RELOPS-1555?focusedCommentId=1076567
+    - defaults:
+    - NV_domain:
+    - Validate:
+    - hw_class:
+    - "t-nuc12"
+    - "nuc13"
+    - Known-BAD:
+    - ##
+    - nuc13:
+    - ##
+    - ##
     - nuc13-112
-    ## TLS errors on PXE boot.
-    ## https://mozilla-hub.atlassian.net/browse/RELOPS-1555?focusedCommentId=1076567
+    - ##
+    - ##
     - nuc13-107
-    ## Dead
-    ## Different model as well
+    - ##
+    - ##
     - t-nuc12-001


### PR DESCRIPTION
## Summary

Removes down and suspect nodes from `win11-64-24h2-hw` based on fleet CPU stress testing (2026-04-22/23) and 7-day Event 37 audit. See [RELOPS-2323](https://mozilla-hub.atlassian.net/browse/RELOPS-2323) for full methodology and [RELOPS-2344](https://mozilla-hub.atlassian.net/browse/RELOPS-2344) for reorganization plan.

## Pool changes

| Pool | Before | After | Change |
|---|---|---|---|
| win11-64-24h2-hw (main) | 175 nodes | 134 nodes | -41 |
| win11-64-24h2-hw-relops1213 | placeholder | 20 down nodes | offline/bad PSU |
| win11-64-24h2-hw-alpha | placeholder | 21 questionable nodes | suspect CPU behavior |
| win11-64-24h2-hw-perf-debug | placeholder (nuc13-902) | unchanged | — |

## Nodes moved to win11-64-24h2-hw-relops1213 (down/offline — 20 nodes)

Bad PSU or persistent SSH failure: nuc13-024, nuc13-035, nuc13-036, nuc13-045, nuc13-059, nuc13-060, nuc13-061, nuc13-068, nuc13-070, nuc13-075, nuc13-096, nuc13-124, nuc13-130, nuc13-132, nuc13-149, nuc13-150, nuc13-154, nuc13-155, nuc13-156, nuc13-157

## Nodes moved to win11-64-24h2-hw-alpha (questionable — 21 nodes)

**Tier 1 — severe CPU suppression (PSU swap urgent):** nuc13-077, nuc13-080, nuc13-147

**Tier 2 — moderate CPU suppression (PSU swap queued):** nuc13-058, nuc13-065, nuc13-158, nuc13-159

**Tier 3 — notable floor events / monitor:** nuc13-010, nuc13-015, nuc13-019, nuc13-027, nuc13-032, nuc13-063, nuc13-097, nuc13-106, nuc13-120, nuc13-139, nuc13-145

**Inconsistent — suppression seen in one run, clean in another:** nuc13-067, nuc13-079, nuc13-148

## Test plan
- [ ] Confirm main pool has 134 nodes
- [ ] Confirm no overlap between pools
- [ ] Confirm nuc13-021 (perf-sheriff) and nuc13-107/112 (Known-BAD) unchanged