### PR TITLE
Update generic-worker-win2022-gpu.yaml

### DIFF
--- a/config/tceng/generic-worker-win2022-gpu.yaml
+++ b/config/tceng/generic-worker-win2022-gpu.yaml
@@ -6,6 +6,9 @@ image:
   version: latest
 azure:
   locations:
+    - eastus
+    - eastus2
+    - southcentralus
     - westus2
   managed_image_resource_group_name: "rg-tc-eng-images"
   managed_image_storage_account_type: "Standard_LRS"


### PR DESCRIPTION
Add a few more locations so fuzzing team doesn't hit quota issues

https://community-tc.services.mozilla.com/worker-manager/proj-fuzzing%2Fci-clauditor-workers

Hitting:

>"Operation could not be completed as it results in exceeding approved standardNVSv3Family Cores quota. Location: westus2, Current Limit: 150, Current Usage: 144, Additional Required: 12, New Limit Required: 156."