### PR TITLE
Migrate wizcli download to v1 channel

### DIFF
--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Download Wiz CLI
         if: ${{ success() && !contains(matrix.config, 'trusted') }}
-        run: curl -o wizcli https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
+        run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
       - name: Authenticate to Wiz
         if: ${{ success() && !contains(matrix.config, 'trusted') }}

--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -115,3 +115,6 @@ jobs:
           --secrets \
           --show-vulnerability-details \
           --policy-hits-only
+        env:
+          WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
+          WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}

--- a/.github/workflows/gcp-fxci.yml
+++ b/.github/workflows/gcp-fxci.yml
@@ -99,3 +99,6 @@ jobs:
           --secrets \
           --show-vulnerability-details \
           --policy-hits-only
+        env:
+          WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
+          WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}

--- a/.github/workflows/gcp-fxci.yml
+++ b/.github/workflows/gcp-fxci.yml
@@ -84,7 +84,7 @@ jobs:
     if: ${{ !contains(github.event.inputs.config, 'trusted') }}
     steps:
       - name: Download Wiz CLI
-        run: curl -o wizcli https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
+        run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
       - name: Authenticate to Wiz
         run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
         env:


### PR DESCRIPTION
## Summary
- The `https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64` URL used by both GCP build workflows still serves WizCLI 0.109.x. The 0.X line reaches End of Support on April 15, 2026, and the binary itself prints a migration warning at startup.
- Switch both workflows to `https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64`, which currently serves 1.45.x.
- No other changes: `wizcli auth --id/--secret` and `wizcli vm-image scan` continue to work in v1.x, so the existing auth and scan steps are left untouched.

## Background
- [Introducing Wiz CLI v1](https://docs.wiz.io/docs/introducing-wiz-cli-v1)
- v0 binary at `/wizcli/latest/` prints: `WARNING: WizCLI 0.X will reach End of Support on April 15, 2026. Please migrate to 1.X now`
- v1 binary at `/v1/wizcli/latest/` reports: `Wiz CLI v1.45.0`

## Test plan
- [ ] Trigger `FXCI - GCP` workflow (`gcp-fxci.yml`) on an untrusted config and confirm the Wiz scan job downloads the v1 binary, authenticates, and completes
- [ ] Trigger `gcp-fxci-parallel-alpha.yml` on an untrusted alpha config and confirm the same
- [ ] Confirm scan results still publish to the Wiz portal as expected