### PR TITLE
Fix GCP NVIDIA toolkit provisioning

### DIFF
--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -241,6 +241,7 @@ build {
     execute_command     = "sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
     expect_disconnect   = true
     pause_before        = "30s"
+    pause_after         = "90s"
     start_retry_timeout = "30m"
     scripts = [
       "${path.cwd}/scripts/linux/common/reboot.sh"
@@ -252,8 +253,7 @@ build {
       "googlecompute.gw-fxci-gcp-l1-2404-headless-alpha",
       "googlecompute.gw-fxci-gcp-l1-2404-arm64-headless-alpha"
     ]
-    execute_command   = "sudo -S bash -c '{{ .Vars }} {{ .Path }}'"
-    expect_disconnect = true
+    execute_command = "sudo -S bash -c '{{ .Vars }} {{ .Path }}'"
     scripts = [
       "${path.cwd}/scripts/linux/ubuntu-2404-amd64-headless/fxci/nvidia-container-toolkit.sh"
     ]
@@ -267,6 +267,7 @@ build {
     execute_command     = "sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
     expect_disconnect   = true
     pause_before        = "30s"
+    pause_after         = "90s"
     start_retry_timeout = "30m"
     scripts = [
       "${path.cwd}/scripts/linux/common/reboot.sh"

--- a/scripts/linux/ubuntu-2404-amd64-headless/fxci/nvidia-container-toolkit.sh
+++ b/scripts/linux/ubuntu-2404-amd64-headless/fxci/nvidia-container-toolkit.sh
@@ -29,12 +29,15 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dear
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
     sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
-apt-get update
+retry apt-get update
 ## Install nvidia-container-toolkit
-apt-get install -y nvidia-container-toolkit
+retry apt-get install -y nvidia-container-toolkit
+command -v nvidia-ctk
+nvidia-ctk --version
 ## Configure docker to use nvidia container runtime
 nvidia-ctk runtime configure --runtime=docker
 ## Restart docker daemon to take effect
 systemctl restart docker
 ## export the docker daemon config
 cat /etc/docker/daemon.json
+grep -q '"nvidia"' /etc/docker/daemon.json


### PR DESCRIPTION
## Summary
- wait after the reboot provisioners that bracket NVIDIA toolkit setup
- fail the build if the NVIDIA toolkit provisioner disconnects unexpectedly
- retry toolkit apt operations and assert `nvidia-ctk` plus Docker NVIDIA runtime config are present

## Why
`mozilla-releng/fxci-config#968` exposed GPU task failures on `translations-1/b-linux-v100-gpu-d2g-4-300gb`. The affected image had NVIDIA drivers loaded and four V100s attached, but `nvidia-gpu-setup.service` failed with `nvidia-ctk: not found`, and Docker failed task startup with `failed to discover GPU vendor from CDI: no known GPU vendor found`.

The image build log from https://github.com/mozilla-platform-ops/worker-images/actions/runs/25331247807 shows the AMD64 headless NVIDIA toolkit step stopped after `apt-get update`; the later reboot/disconnect was accepted because that provisioner had `expect_disconnect = true`. Keeping expected disconnects on the explicit reboot steps but removing it from the toolkit install makes this fail during image build instead of publishing a partial GPU image.

Related PRs / runs:
- https://github.com/mozilla-releng/fxci-config/pull/968
- https://github.com/mozilla-releng/fxci-config/pull/969
- https://github.com/mozilla-platform-ops/worker-images/actions/runs/25331247807

## Validation
- `bash -n scripts/linux/ubuntu-2404-amd64-headless/fxci/nvidia-container-toolkit.sh`
- `packer fmt -check gcp.pkr.hcl`
- `PROJECT_ID=dummy IMAGE_NAME=dummy SOURCE_IMAGE_FAMILY=ubuntu-2404-lts-amd64 ZONE=us-central1-a ACCESS_TOKEN=dummy TASKCLUSTER_VERSION=dummy TASKCLUSTER_REF=dummy TC_ARCH=amd64 packer validate gcp.pkr.hcl`