### PR TITLE
fix(tceng): run azure bootstrap as local system

### DIFF
--- a/packer/tceng-azure.pkr.hcl
+++ b/packer/tceng-azure.pkr.hcl
@@ -92,6 +92,8 @@ build {
   }
 
   provisioner "powershell" {
+    elevated_password = ""
+    elevated_user     = "SYSTEM"
     environment_vars = [
       "TASKCLUSTER_REF=${var.taskcluster_ref}",
       "TASKCLUSTER_VERSION=${var.taskcluster_version}",


### PR DESCRIPTION
Hitting the following issue in community due to the runner.yml config file being written as the Administrator user:

```
2026/05/07 18:54:01 error loading runner config file C:\worker-runner\runner.yml: cannot secure runner config file C:\worker-runner\runner.yml: C:\worker-runner\runner.yml is owned by S-1-5-32-544 (expected S-1-5-18); refusing to tighten permissions on a file owned by another user
```

Due to https://docs.taskcluster.net/docs/changelog?version=v99.2.0&audience=WORKER-DEPLOYERS