### PR TITLE
fix(tceng): preserve packer scheduled tasks

### DIFF
--- a/scripts/windows/tceng/generic-worker-win2022-staging.ps1
+++ b/scripts/windows/tceng/generic-worker-win2022-staging.ps1
@@ -227,7 +227,9 @@ foreach ($service in $servicesToDisable) {
     "\Microsoft\Windows\WindowsUpdate\"
     "\Microsoft\XblGameSave\"
 ) | ForEach-Object {
-    Get-ScheduledTask -TaskPath $_ -ErrorAction Ignore | Disable-ScheduledTask -ErrorAction Ignore
+    Get-ScheduledTask -TaskPath $_ -ErrorAction Ignore |
+        Where-Object { $_.TaskName -notlike "packer-*" } |
+        Disable-ScheduledTask -ErrorAction Ignore
 } | Out-Null
 
 # install chocolatey package manager

--- a/scripts/windows/tceng/generic-worker-win2022.ps1
+++ b/scripts/windows/tceng/generic-worker-win2022.ps1
@@ -222,7 +222,9 @@ foreach ($service in $servicesToDisable) {
     "\Microsoft\Windows\WindowsUpdate\"
     "\Microsoft\XblGameSave\"
 ) | ForEach-Object {
-    Get-ScheduledTask -TaskPath $_ -ErrorAction Ignore | Disable-ScheduledTask -ErrorAction Ignore
+    Get-ScheduledTask -TaskPath $_ -ErrorAction Ignore |
+        Where-Object { $_.TaskName -notlike "packer-*" } |
+        Disable-ScheduledTask -ErrorAction Ignore
 } | Out-Null
 
 # install chocolatey package manager

--- a/scripts/windows/tceng/generic-worker-win2025-staging.ps1
+++ b/scripts/windows/tceng/generic-worker-win2025-staging.ps1
@@ -227,7 +227,9 @@ foreach ($service in $servicesToDisable) {
     "\Microsoft\Windows\WindowsUpdate\"
     "\Microsoft\XblGameSave\"
 ) | ForEach-Object {
-    Get-ScheduledTask -TaskPath $_ -ErrorAction Ignore | Disable-ScheduledTask -ErrorAction Ignore
+    Get-ScheduledTask -TaskPath $_ -ErrorAction Ignore |
+        Where-Object { $_.TaskName -notlike "packer-*" } |
+        Disable-ScheduledTask -ErrorAction Ignore
 } | Out-Null
 
 # install chocolatey package manager


### PR DESCRIPTION
## Summary
- Exclude Packer's temporary `packer-*` scheduled tasks from the tceng bootstrap scheduled-task disable pass.
- Apply the fix to all tceng Windows bootstrap scripts that disable scheduled tasks.
- Preserve the Azure Packer bootstrap running as `SYSTEM`.

## Why
The Azure Packer PowerShell provisioner runs the bootstrap as `SYSTEM` via a temporary scheduled task. The tceng bootstrap disables tasks under the root task path, which also disables Packer's own `packer-*` task while Packer is waiting for that task to return to `Ready`. That can leave the build stuck even after the bootstrap completes.

## Validation
- `git diff --check`
- PowerShell parser pass for:
  - `scripts/windows/tceng/generic-worker-win2022.ps1`
  - `scripts/windows/tceng/generic-worker-win2022-staging.ps1`
  - `scripts/windows/tceng/generic-worker-win2025-staging.ps1`
