### PR TITLE
linux: add PyAutoGUI deps to Wayland image

### DIFF
--- a/scripts/linux/ubuntu-2404-amd64-gui/fxci/additional-packages.sh
+++ b/scripts/linux/ubuntu-2404-amd64-gui/fxci/additional-packages.sh
@@ -32,6 +32,9 @@ MISC_PACKAGES=()
 MISC_PACKAGES+=(build-essential curl git gnupg-agent jq mercurial)
 # python things
 MISC_PACKAGES+=(python3-pip python3-certifi python3-psutil)
+# PyAutoGUI imports MouseInfo on Linux, which requires tkinter. Keep
+# python3-dev available for packages that still need native extension headers.
+MISC_PACKAGES+=(python3-tk python3-dev)
 # zstd packages
 MISC_PACKAGES+=(zstd python3-zstd)
 # install zstandard to avoid installing via pip and breaking via PEP 668 https://peps.python.org/pep-0668/


### PR DESCRIPTION
## Summary
- Add `python3-tk` and `python3-dev` to the Ubuntu 24.04 GUI/Wayland package list.
- Keep the change scoped to the Wayland alpha image path used by `gw-fxci-gcp-l1-2404-gui-alpha`.

## Context
Ben's fx-desktop PR mozilla/fx-desktop-qa-automation#1294 moves Linux coverage toward PyAutoGUI. In the Xauthority follow-up PR, mozilla/fx-desktop-qa-automation#1310, the task got past X auth and then failed importing PyAutoGUI because MouseInfo requires tkinter on Linux.

This adds the base OS packages requested for that path. `python3-tk` provides tkinter, and `python3-dev` matches the Linux package guidance from the import failure when native Python headers are needed.

## Testing
- `bash -n scripts/linux/ubuntu-2404-amd64-gui/fxci/additional-packages.sh`
- `git diff --check`

I did not build the image locally.
