### PR TITLE
mdc1: realign win11-64-24h2-hw to SP3 stress-test allowlist (RELOPS-2323)

### DIFF
--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -106,25 +106,69 @@ pools:
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
-    - nuc13-010
-    - nuc13-015
     - nuc13-019
-    - nuc13-027
-    - nuc13-032
+    - nuc13-020
+    - nuc13-022
+    - nuc13-023
+    - nuc13-028
+    - nuc13-029
+    - nuc13-030
+    - nuc13-031
+    - nuc13-034
+    - nuc13-037
+    - nuc13-039
+    - nuc13-042
+    - nuc13-043
+    - nuc13-044
+    - nuc13-051
+    - nuc13-052
+    - nuc13-053
+    - nuc13-055
     - nuc13-058
+    - nuc13-062
     - nuc13-063
     - nuc13-065
     - nuc13-067
+    - nuc13-069
+    - nuc13-071
+    - nuc13-072
+    - nuc13-073
+    - nuc13-074
+    - nuc13-076
     - nuc13-077
+    - nuc13-078
     - nuc13-079
     - nuc13-080
-    - nuc13-097
+    - nuc13-084
+    - nuc13-085
+    - nuc13-094
+    - nuc13-095
+    - nuc13-099
+    - nuc13-102
+    - nuc13-103
+    - nuc13-105
     - nuc13-106
+    - nuc13-111
+    - nuc13-114
+    - nuc13-115
+    - nuc13-116
+    - nuc13-119
     - nuc13-120
+    - nuc13-122
+    - nuc13-125
+    - nuc13-129
+    - nuc13-131
+    - nuc13-133
+    - nuc13-137
+    - nuc13-138
     - nuc13-139
-    - nuc13-145
+    - nuc13-140
+    - nuc13-143
+    - nuc13-144
+    - nuc13-146
     - nuc13-147
     - nuc13-148
+    - nuc13-152
     - nuc13-158
     - nuc13-159
   - name: "win11-64-24h2-hw-perf-sheriff"
@@ -163,59 +207,36 @@ pools:
     - nuc13-007
     - nuc13-008
     - nuc13-009
+    - nuc13-010
     - nuc13-011
     - nuc13-012
     - nuc13-013
     - nuc13-014
+    - nuc13-015
     - nuc13-016
     - nuc13-017
     - nuc13-018
-    - nuc13-020
-    - nuc13-022
-    - nuc13-023
     - nuc13-025
     - nuc13-026
-    - nuc13-028
-    - nuc13-029
-    - nuc13-030
-    - nuc13-031
+    - nuc13-027
+    - nuc13-032
     - nuc13-033
-    - nuc13-034
-    - nuc13-037
     - nuc13-038
-    - nuc13-039
     - nuc13-040
     - nuc13-041
-    - nuc13-042
-    - nuc13-043
-    - nuc13-044
     - nuc13-046
     - nuc13-047
     - nuc13-048
     - nuc13-049
     - nuc13-050
-    - nuc13-051
-    - nuc13-052
-    - nuc13-053
     - nuc13-054
-    - nuc13-055
     - nuc13-056
     - nuc13-057
-    - nuc13-062
     - nuc13-064
     - nuc13-066
-    - nuc13-069
-    - nuc13-071
-    - nuc13-072
-    - nuc13-073
-    - nuc13-074
-    - nuc13-076
-    - nuc13-078
     - nuc13-081
     - nuc13-082
     - nuc13-083
-    - nuc13-084
-    - nuc13-085
     - nuc13-086
     - nuc13-087
     - nuc13-088
@@ -224,50 +245,29 @@ pools:
     - nuc13-091
     - nuc13-092
     - nuc13-093
-    - nuc13-094
-    - nuc13-095
+    - nuc13-097
     - nuc13-098
-    - nuc13-099
     - nuc13-100
     - nuc13-101
-    - nuc13-102
-    - nuc13-103
     - nuc13-104
-    - nuc13-105
     - nuc13-108
     - nuc13-109
     - nuc13-110
-    - nuc13-111
     - nuc13-113
-    - nuc13-114
-    - nuc13-115
-    - nuc13-116
     - nuc13-117
     - nuc13-118
-    - nuc13-119
     - nuc13-121
-    - nuc13-122
     - nuc13-123
-    - nuc13-125
     - nuc13-126
     - nuc13-127
     - nuc13-128
-    - nuc13-129
-    - nuc13-131
-    - nuc13-133
     - nuc13-134
     - nuc13-135
     - nuc13-136
-    - nuc13-137
-    - nuc13-138
-    - nuc13-140
     - nuc13-141
     - nuc13-142
-    - nuc13-143
-    - nuc13-144
-    - nuc13-146
+    - nuc13-145
     - nuc13-151
-    - nuc13-152
     - nuc13-153
     - nuc13-160
 defaults:


### PR DESCRIPTION
## Summary

Align the `win11-64-24h2-hw` production pool with the 72 nodes recommended by the 5-loop StressSP3 fleet sweep on 2026-05-07. Source: [RELOPS-2323 comment #1420888](https://mozilla-hub.atlassian.net/browse/RELOPS-2323?focusedCommentId=1420888).

**Net effect** in `provisioners/windows/MDC1Windows/pools.yml`:

| Pool | Before | After | Change |
| --- | --- | --- | --- |
| `win11-64-24h2-hw` | 116 | 72 | -44 |
| `win11-64-24h2-hw-alpha` | 21 | 65 | +44 |

## Why

The 5-loop StressSP3 sweep ran the actual Speedometer3 workload (the same one CI exercises) against 142 NUC13 nodes back-to-back. The resulting final score correlates with last week's CI Speedometer3 mean at **r = 0.837** (n=105), compared to **r = 0.48** for the previous brief CPU-burner triage scan. The 5-loop result is the strongest CI predictor we have — strong enough to act on directly.

### Inclusion criteria for `win11-64-24h2-hw` (must pass all)

- 5-loop final score >= 13.0 (calibrated between the T5 mean of 13.62 and the T2 mean of 12.44; fleet median is 13.50)
- No thermal-degrade signature (`(loop1+loop2)/2 - loop5 < 1.5 pts`) — catches the new failure mode found in nuc13-129 / 131
- Completed all 5/5 loops (no Python-missing, no SSH failures, no unreachable)

### Moved hw -> hw-alpha (50 nodes)

Subdivided by reason:

- **Low final score (<13.0)** — original Tier 2 / no-turbo cluster plus "anomalous-bad" Tier 4/5 nodes that underperform under sustained workload:
  020, 022, 023, 028, 029, 030, 031, 034, 039, 042, 043, 044, 052, 053, 055, 062, 069, 071, 073, 074, 076, 078, 084, 085, 094, 095, 099, 102, 103, 105, 114, 115, 116, 119, 122, 125, 133, 137, 138, 140, 143, 144, 146
- **Thermal degraders** (new finding — clean downward curve across 5 loops, Tier 4 in burner, fine in CI mean — burner and CI both averaged this signal away):
  129, 131
- **Python-missing** (Mozilla-Build `python3` not installed; Microsoft Store alias firing — needs MB python3 before re-test):
  037, 051, 072, 111
- **cmd-shell SSH bug** (default SSH shell is `cmd.exe`; `; Remove-Item` trailer in `StressSP3.ps1` parsed as part of `-File` — fix already in `Scan-NUCHealth.ps1`, needs porting):
  152

### Moved hw-alpha -> hw (6 nodes)

These were demoted earlier as "questionable / CPU-suppression suspected" but the 5-loop run clears them with healthy scores across all 5 loops: **010, 015, 027, 032, 097, 145**.

### Out-of-scope follow-ups not addressed in this PR

- `nuc13-120` is now fully unreachable (port 22 timeout) after yesterday's punishing run — needs physical/console intervention. It remains in hw-alpha for now.
- 3 truly unreachable nodes (024, 158, 159) — port 22 timeout, need physical/network triage. 024 is already in `win11-64-24h2-hw-relops1213`; 158/159 stay in hw-alpha.
- The hw-alpha description string (*"Questionable nodes - CPU suppression confirmed or notable floor events..."*) no longer fully covers the populations now in the pool (thermal degraders, Python-missing, cmd-shell bug, unreachable). Worth a separate cleanup PR if we want narrower pool semantics.
- Port the cmd-shell SSH fix from `Scan-NUCHealth.ps1` into `StressSP3.ps1`.

## Test plan

- [ ] `python3 -c "import yaml; yaml.safe_load(open('provisioners/windows/MDC1Windows/pools.yml'))"` parses cleanly
- [ ] No node appears in more than one nuc13 pool
- [ ] `win11-64-24h2-hw` node list exactly equals the 72-node "Recommended for SP3" list in the RELOPS-2323 comment
- [ ] Downstream tooling (provisioning, taskcluster worker registration) picks up new pool membership on next run