### PR TITLE
mdc1: add NUC13 stress-test PowerShell toolkit (RELOPS-2323)

### DIFF
--- a/provisioners/windows/MDC1Windows/utility_scripts/stress_test/CleanupSP3.ps1
+++ b/provisioners/windows/MDC1Windows/utility_scripts/stress_test/CleanupSP3.ps1
@@ -1,0 +1,77 @@
+# CleanupSP3.ps1
+# Resets per-node state left behind by aborted/timed-out StressSP3 runs.
+# Default targets the 3-node compare set; override with -nodes "a,b,c".
+#
+# What it does on each node (via SSH as Administrator):
+#   - kills any leftover firefox.exe
+#   - stops any active xperf NT Kernel Logger session
+#   - stops any leftover logman trace whose name starts with StressProcPower_
+#   - unregisters any scheduled task named StressSP3_FF_*
+#   - deletes stress_payload_*.ps1 from the Administrator home dir
+#   - deletes the C:\Users\Public\sp3stress workdir
+#
+# Usage:
+#   .\CleanupSP3.ps1                                    # cleans nuc13-009, -010, -029
+#   .\CleanupSP3.ps1 -nodes "nuc13-029"                 # one node
+#   .\CleanupSP3.ps1 -nodes "nuc13-029,nuc13-010"       # custom list
+#   .\CleanupSP3.ps1 -ssh_user Administrator            # override login user
+
+param(
+    [string]$nodes    = "nuc13-009,nuc13-010,nuc13-029",
+    [string]$ssh_user = "Administrator",
+    [string]$domain_suffix = "wintest2.releng.mdc1.mozilla.com"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$target_shorts = @($nodes -split '[,\s]+' | Where-Object { $_ } | ForEach-Object { ($_ -replace '\..*$', '').Trim() })
+if ($target_shorts.Count -eq 0) { Write-Error "No nodes specified."; exit 1 }
+
+$cleanup = @'
+$ErrorActionPreference = 'SilentlyContinue'
+Get-Process firefox -EA 0 | Stop-Process -Force -EA 0
+& xperf -stop 2>$null | Out-Null
+logman query -ets 2>$null | Select-String StressProcPower_ | ForEach-Object {
+    $name = ($_.Line -split '\s+')[0]
+    & logman stop $name -ets 2>$null | Out-Null
+}
+Get-ScheduledTask -TaskName 'StressSP3_FF_*' -EA 0 | Unregister-ScheduledTask -Confirm:$false -EA 0
+Remove-Item 'C:\Users\Administrator\stress_payload_*.ps1' -Force -EA 0
+Remove-Item 'C:\Users\Public\sp3stress' -Recurse -Force -EA 0
+Write-Host "cleaned $env:COMPUTERNAME"
+'@
+
+Write-Host ""
+Write-Host "------------------------------------------------------------"
+Write-Host "  CleanupSP3 - resetting per-node state"
+Write-Host "  Nodes: $($target_shorts -join ', ')"
+Write-Host "  User : $ssh_user"
+Write-Host "------------------------------------------------------------"
+Write-Host ""
+
+$failed = @()
+foreach ($short in $target_shorts) {
+    $fqdn = "$short.$domain_suffix"
+    Write-Host "--- $fqdn ---"
+    try {
+        & ssh -o ConnectTimeout=15 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no `
+            "$ssh_user@$fqdn" "powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command $cleanup"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  SSH exit code: $LASTEXITCODE"
+            $failed += $fqdn
+        }
+    } catch {
+        Write-Host "  Error: $($_.Exception.Message)"
+        $failed += $fqdn
+    }
+    Write-Host ""
+}
+
+Write-Host "==== DONE ===="
+if ($failed.Count -gt 0) {
+    Write-Host "Failed:"
+    $failed | ForEach-Object { Write-Host "  - $_" }
+    exit 1
+}
+Write-Host "All nodes cleaned."

--- a/provisioners/windows/MDC1Windows/utility_scripts/stress_test/Compare-NUCHealth.ps1
+++ b/provisioners/windows/MDC1Windows/utility_scripts/stress_test/Compare-NUCHealth.ps1
@@ -1,0 +1,334 @@
+# Compare-NUCHealth.ps1
+# Side-by-side hardware/firmware/software comparison across NUC13 nodes.
+# Designed for diffing the SP3 throttling-investigation compare set:
+#   nuc13-009 (good) vs nuc13-010 (susp PSU) vs nuc13-029 (bad, unknown).
+#
+# Per node, captures a quick (<60s) snapshot of:
+#   - active power plan + min/max processor state
+#   - CPU model, max clock, current clock, achieved %perf under brief load
+#   - RAM total / channel / per-DIMM (speed, capacity, manufacturer, part, location)
+#   - storage media type + model + bus + size for each physical disk
+#   - BIOS version + release date
+#   - top 5 processes by CPU and by working set
+#   - OS build + uptime
+#
+# Output: prints a side-by-side comparison table (one row per metric, one column per node).
+#
+# Usage:
+#   .\Compare-NUCHealth.ps1                                    # default 3-node compare set
+#   .\Compare-NUCHealth.ps1 -nodes "nuc13-029"                 # one node
+#   .\Compare-NUCHealth.ps1 -nodes "nuc13-009,nuc13-010"       # custom list
+#   .\Compare-NUCHealth.ps1 -ssh_user Administrator
+
+param(
+    [string]$nodes         = "nuc13-009,nuc13-010,nuc13-029",
+    [string]$ssh_user      = "Administrator",
+    [string]$domain_suffix = "wintest2.releng.mdc1.mozilla.com"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$target_shorts = @($nodes -split '[,\s]+' | Where-Object { $_ } | ForEach-Object { ($_ -replace '\..*$', '').Trim() })
+if ($target_shorts.Count -eq 0) { Write-Error "No nodes specified."; exit 1 }
+
+# ------------------ Remote payload ------------------
+# Returns one JSON object per node with all the diagnostic fields we want to diff.
+$diagPayload = @"
+`$ErrorActionPreference = 'Continue'
+
+# --- Active power plan ---
+`$pwrSchemeOut = & powercfg /getactivescheme 2>`$null
+`$pwrPlan = if (`$pwrSchemeOut -match 'GUID:\s+([a-f0-9-]+)\s+\((.+)\)') { `$matches[2] } else { 'unknown' }
+`$pwrGuid = if (`$pwrSchemeOut -match 'GUID:\s+([a-f0-9-]+)') { `$matches[1] } else { '' }
+
+# Processor min/max state (sub_processor 893dee8e-2bef-41e0-89c6-b55d0929964c PROCTHROTTLEMIN/MAX)
+function Get-PwrPctValue {
+    param([string]`$Guid, [string]`$SubGuid, [string]`$SettingGuid)
+    `$out = & powercfg /query `$Guid `$SubGuid `$SettingGuid 2>`$null
+    `$line = `$out | Where-Object { `$_ -match 'Current AC Power Setting Index:\s+0x([0-9a-f]+)' } | Select-Object -First 1
+    if (`$line -match '0x([0-9a-f]+)') { return [int]("0x" + `$matches[1]) }
+    return `$null
+}
+`$procMin = Get-PwrPctValue -Guid `$pwrGuid -SubGuid '54533251-82be-4824-96c1-47b60b740d00' -SettingGuid '893dee8e-2bef-41e0-89c6-b55d0929964c'
+`$procMax = Get-PwrPctValue -Guid `$pwrGuid -SubGuid '54533251-82be-4824-96c1-47b60b740d00' -SettingGuid 'bc5038f7-23e0-4960-96da-33abaf5935ec'
+
+# --- CPU info ---
+`$cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+`$cpuName = `$cpu.Name
+`$cpuMaxMHz = `$cpu.MaxClockSpeed
+`$cpuCurMHz = `$cpu.CurrentClockSpeed
+`$cpuCores = `$cpu.NumberOfCores
+`$cpuLP = `$cpu.NumberOfLogicalProcessors
+
+# --- Achieved %Performance under brief load ---
+# Spin a short CPU burner on one logical core for 4s, sample %Processor Performance counter.
+`$perfPctSamples = @()
+`$burnerJob = Start-Job -ScriptBlock { `$end = (Get-Date).AddSeconds(5); while ((Get-Date) -lt `$end) { `$x = 0; for (`$i=0; `$i -lt 1000000; `$i++) { `$x = `$x + `$i } } }
+Start-Sleep -Seconds 1
+for (`$s = 0; `$s -lt 4; `$s++) {
+    try {
+        `$ctr = (Get-Counter '\Processor Information(_Total)\% Processor Performance' -ErrorAction Stop).CounterSamples[0].CookedValue
+        `$perfPctSamples += [math]::Round(`$ctr, 1)
+    } catch {}
+    Start-Sleep -Milliseconds 800
+}
+Stop-Job `$burnerJob -ErrorAction SilentlyContinue
+Remove-Job `$burnerJob -Force -ErrorAction SilentlyContinue
+`$perfPctMax = if (`$perfPctSamples.Count -gt 0) { (`$perfPctSamples | Measure-Object -Maximum).Maximum } else { `$null }
+`$perfPctSamplesStr = `$perfPctSamples -join ','
+
+# --- RAM / DIMMs ---
+`$ramDimms = @(Get-CimInstance Win32_PhysicalMemory)
+`$ramTotalGB = [math]::Round((`$ramDimms | Measure-Object -Property Capacity -Sum).Sum / 1GB, 1)
+`$ramSlots = `$ramDimms.Count
+`$ramSpeeds = (`$ramDimms | ForEach-Object { `$_.ConfiguredClockSpeed } | Sort-Object -Unique) -join '/'
+`$ramConfiguredSpeed = (`$ramDimms | ForEach-Object { `$_.ConfiguredClockSpeed } | Select-Object -First 1)
+`$ramRatedSpeeds = (`$ramDimms | ForEach-Object { `$_.Speed } | Sort-Object -Unique) -join '/'
+`$dimmDetail = (`$ramDimms | ForEach-Object {
+    `$cap = [math]::Round(`$_.Capacity / 1GB, 0)
+    `$loc = if (`$_.DeviceLocator) { `$_.DeviceLocator } else { 'slot?' }
+    `$mfr = if (`$_.Manufacturer) { (`$_.Manufacturer -replace '\s+',' ').Trim() } else { '?' }
+    `$pn  = if (`$_.PartNumber) { (`$_.PartNumber -replace '\s+',' ').Trim() } else { '?' }
+    `$conf = if (`$_.ConfiguredClockSpeed) { `$_.ConfiguredClockSpeed } else { '?' }
+    `$rated = if (`$_.Speed) { `$_.Speed } else { '?' }
+    "`${loc}:`${cap}GB@`${conf}MHz(rated=`${rated}) `${mfr}/`${pn}"
+}) -join ' | '
+
+# --- Storage ---
+`$disks = @(Get-PhysicalDisk -ErrorAction SilentlyContinue | Sort-Object DeviceId)
+`$diskDetail = (`$disks | ForEach-Object {
+    `$sz = [math]::Round(`$_.Size / 1GB, 0)
+    "`$(`$_.DeviceId):`$(`$_.MediaType)/`$(`$_.BusType) `$(`$_.Model) (`${sz}GB)"
+}) -join ' | '
+
+# --- BIOS ---
+`$bios = Get-CimInstance Win32_BIOS
+`$biosVer = `$bios.SMBIOSBIOSVersion
+`$biosDate = if (`$bios.ReleaseDate) { (`$bios.ReleaseDate).ToString('yyyy-MM-dd') } else { '?' }
+`$biosManufacturer = `$bios.Manufacturer
+
+# --- OS ---
+`$os = Get-CimInstance Win32_OperatingSystem
+`$osBuild = `$os.BuildNumber
+`$osVersion = `$os.Version
+`$uptimeMin = [int]((Get-Date) - `$os.LastBootUpTime).TotalMinutes
+
+# --- Top processes by CPU and by memory ---
+`$procs = Get-Process | Where-Object { `$_.ProcessName -ne 'Idle' }
+`$topCpu = (`$procs | Sort-Object CPU -Desc | Select-Object -First 5 | ForEach-Object { "`$(`$_.ProcessName)(CPU=`$([math]::Round(`$_.CPU,0))s)" }) -join ', '
+`$topMem = (`$procs | Sort-Object WorkingSet64 -Desc | Select-Object -First 5 | ForEach-Object { "`$(`$_.ProcessName)(`$([math]::Round(`$_.WorkingSet64/1MB,0))MB)" }) -join ', '
+
+# --- Worker / busy state ---
+`$wsp = `$null
+foreach (`$p in @("C:\WINDOWS\SystemTemp", `$env:TMP, `$env:TEMP, `$env:USERPROFILE)) {
+    if (`$p) { `$c = Join-Path `$p "worker-status.json"; if (Test-Path `$c) { `$wsp = `$c; break } }
+}
+`$busy = `$false
+if (`$wsp) {
+    try { `$j = Get-Content `$wsp -Raw | ConvertFrom-Json; if (@(`$j.currentTaskIds).Count -gt 0) { `$busy = `$true } } catch {}
+}
+
+# --- Active interactive task user ---
+`$taskUser = `$null
+try {
+    `$qu = & query user 2>`$null
+    foreach (`$line in `$qu) {
+        if (`$line -match '^\s*>?\s*(\S+)\s+\S+\s+(\d+)\s+Active') {
+            `$u = `$matches[1]
+            if (`$u -notmatch '^(Administrator|administrator|SYSTEM)$' -and `$u -ne `$env:USERNAME) {
+                `$taskUser = `$u; break
+            }
+        }
+    }
+} catch {}
+
+[pscustomobject]@{
+    Hostname            = `$env:COMPUTERNAME
+    Timestamp           = (Get-Date).ToString('s')
+    PowerPlan           = `$pwrPlan
+    ProcMinPct          = `$procMin
+    ProcMaxPct          = `$procMax
+    CPU                 = `$cpuName
+    CPU_Cores           = `$cpuCores
+    CPU_LogicalProcs    = `$cpuLP
+    CPU_MaxMHz          = `$cpuMaxMHz
+    CPU_CurMHz          = `$cpuCurMHz
+    PerfPct_Samples     = `$perfPctSamplesStr
+    PerfPct_Max         = `$perfPctMax
+    RAM_GB              = `$ramTotalGB
+    RAM_Slots           = `$ramSlots
+    RAM_ConfiguredMHz   = `$ramConfiguredSpeed
+    RAM_RatedMHz        = `$ramRatedSpeeds
+    DIMM_Detail         = `$dimmDetail
+    Disk_Detail         = `$diskDetail
+    BIOS_Manufacturer   = `$biosManufacturer
+    BIOS_Version        = `$biosVer
+    BIOS_Date           = `$biosDate
+    OS_Build            = `$osBuild
+    OS_Version          = `$osVersion
+    Uptime_Min          = `$uptimeMin
+    Worker_Busy         = `$busy
+    TaskUser            = `$taskUser
+    Top_CPU             = `$topCpu
+    Top_Mem             = `$topMem
+} | ConvertTo-Json -Depth 5 -Compress
+"@
+
+# ------------------ Per-node diagnostic via scp + ssh -File ------------------
+function Invoke-NodeDiag {
+    param([string]$NodeName, [string]$User, [string]$Payload)
+
+    $remoteName = "compare_nuchealth_$([guid]::NewGuid().ToString('N')).ps1"
+    $localTemp  = Join-Path $env:TEMP $remoteName
+    Set-Content -Path $localTemp -Value $Payload -Encoding UTF8
+
+    try {
+        $scpArgs = "-O -o ConnectTimeout=15 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no `"$localTemp`" `"${User}@${NodeName}:$remoteName`""
+        $psi = [System.Diagnostics.ProcessStartInfo]::new('scp')
+        $psi.Arguments              = $scpArgs
+        $psi.UseShellExecute        = $false
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError  = $true
+        $psi.CreateNoWindow         = $true
+        $sp = [System.Diagnostics.Process]::Start($psi)
+        $sp.StandardOutput.ReadToEnd() | Out-Null
+        $scpErr = $sp.StandardError.ReadToEnd()
+        $null = $sp.WaitForExit(60000)
+        $scpExit = $sp.ExitCode
+        $sp.Dispose()
+        if ($scpExit -ne 0) {
+            return [pscustomobject]@{ Node = $NodeName; Error = "scp failed (exit $scpExit): $scpErr"; Data = $null }
+        }
+
+        $remoteCmd = "powershell -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File `"`$env:USERPROFILE\$remoteName`"; Remove-Item `"`$env:USERPROFILE\$remoteName`" -Force -ErrorAction SilentlyContinue"
+        $sshArgs = "-o ConnectTimeout=15 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no ${User}@${NodeName} $remoteCmd"
+        $psi2 = [System.Diagnostics.ProcessStartInfo]::new('ssh')
+        $psi2.Arguments              = $sshArgs
+        $psi2.UseShellExecute        = $false
+        $psi2.RedirectStandardOutput = $true
+        $psi2.RedirectStandardError  = $true
+        $psi2.CreateNoWindow         = $true
+        $sp2 = [System.Diagnostics.Process]::Start($psi2)
+        $stdout = $sp2.StandardOutput.ReadToEnd()
+        $stderr = $sp2.StandardError.ReadToEnd()
+        $null = $sp2.WaitForExit(120000)
+        $sshExit = $sp2.ExitCode
+        $sp2.Dispose()
+        if ($sshExit -ne 0) {
+            return [pscustomobject]@{ Node = $NodeName; Error = "ssh failed (exit $sshExit): $stderr"; Data = $null }
+        }
+
+        $jsonLine = ($stdout -split "`n") | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        if (-not $jsonLine) {
+            return [pscustomobject]@{ Node = $NodeName; Error = "no JSON in stdout: $stdout"; Data = $null }
+        }
+        try {
+            $obj = $jsonLine | ConvertFrom-Json
+            return [pscustomobject]@{ Node = $NodeName; Error = $null; Data = $obj }
+        } catch {
+            return [pscustomobject]@{ Node = $NodeName; Error = "JSON parse: $_"; Data = $null }
+        }
+    } finally {
+        Remove-Item $localTemp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ------------------ Run all nodes in parallel ------------------
+Write-Host ""
+Write-Host "------------------------------------------------------------"
+Write-Host "  Compare-NUCHealth"
+Write-Host "  Nodes: $($target_shorts -join ', ')"
+Write-Host "  User : $ssh_user"
+Write-Host "------------------------------------------------------------"
+Write-Host ""
+Write-Host "Collecting diagnostics (each node ~10-30s)..."
+Write-Host ""
+
+$rsPool = [RunspaceFactory]::CreateRunspacePool(1, $target_shorts.Count)
+$rsPool.Open()
+$jobs = [System.Collections.Generic.List[object]]::new()
+foreach ($short in $target_shorts) {
+    $fqdn = "$short.$domain_suffix"
+    $ps = [PowerShell]::Create()
+    $ps.RunspacePool = $rsPool
+    [void]$ps.AddScript(${function:Invoke-NodeDiag})
+    [void]$ps.AddParameters(@{ NodeName = $fqdn; User = $ssh_user; Payload = $diagPayload })
+    $jobs.Add([pscustomobject]@{ Short = $short; Fqdn = $fqdn; PS = $ps; Handle = $ps.BeginInvoke() })
+}
+
+$results = @{}
+foreach ($job in $jobs) {
+    try {
+        $r = $job.PS.EndInvoke($job.Handle)[0]
+    } catch {
+        $r = [pscustomobject]@{ Node = $job.Fqdn; Error = "runspace: $_"; Data = $null }
+    }
+    $job.PS.Dispose()
+    $results[$job.Short] = $r
+    if ($r.Error) {
+        Write-Host "[$($job.Short)] ERROR: $($r.Error)"
+    } else {
+        Write-Host "[$($job.Short)] ok"
+    }
+}
+$rsPool.Close()
+$rsPool.Dispose()
+
+# ------------------ Side-by-side comparison table ------------------
+$rows = @(
+    'PowerPlan','ProcMinPct','ProcMaxPct','',
+    'CPU','CPU_Cores','CPU_LogicalProcs','CPU_MaxMHz','CPU_CurMHz','PerfPct_Max','PerfPct_Samples','',
+    'RAM_GB','RAM_Slots','RAM_ConfiguredMHz','RAM_RatedMHz','DIMM_Detail','',
+    'Disk_Detail','',
+    'BIOS_Manufacturer','BIOS_Version','BIOS_Date','',
+    'OS_Build','OS_Version','Uptime_Min','',
+    'Worker_Busy','TaskUser','',
+    'Top_CPU','Top_Mem'
+)
+
+Write-Host ""
+Write-Host "============================================================"
+Write-Host "  COMPARISON"
+Write-Host "============================================================"
+Write-Host ""
+
+$colNodes = $target_shorts
+$labelWidth = ($rows | Where-Object { $_ } | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum + 2
+$valueWidth = 50
+
+# Header
+$hdr = ("{0,-$labelWidth}" -f "metric")
+foreach ($n in $colNodes) { $hdr += ("{0,-$valueWidth}" -f $n) }
+Write-Host $hdr
+Write-Host (("-" * $labelWidth) + (("-" * $valueWidth) * $colNodes.Count))
+
+foreach ($field in $rows) {
+    if (-not $field) { Write-Host ""; continue }
+    $line = ("{0,-$labelWidth}" -f $field)
+    foreach ($n in $colNodes) {
+        $r = $results[$n]
+        $v = if ($r -and $r.Data -and $r.Data.PSObject.Properties[$field]) {
+            $val = $r.Data.$field
+            if ($null -eq $val) { '<null>' } else { [string]$val }
+        } else { '<no data>' }
+        # Truncate long values for table display
+        if ($v.Length -gt ($valueWidth - 2)) {
+            $v = $v.Substring(0, $valueWidth - 5) + '...'
+        }
+        $line += ("{0,-$valueWidth}" -f $v)
+    }
+    Write-Host $line
+}
+
+# Also dump full JSON to a CSV-adjacent file for reference (long fields not truncated)
+$stamp = (Get-Date).ToString('yyyyMMdd_HHmmss')
+$outDir = "C:\logs"
+if (-not (Test-Path $outDir)) { New-Item -ItemType Directory $outDir -Force | Out-Null }
+$outFile = Join-Path $outDir ("compare_nuchealth_{0}nodes_{1}.json" -f $colNodes.Count, $stamp)
+$dump = @{}
+foreach ($n in $colNodes) { $dump[$n] = if ($results[$n].Data) { $results[$n].Data } else { @{ Error = $results[$n].Error } } }
+$dump | ConvertTo-Json -Depth 6 | Set-Content -Path $outFile -Encoding UTF8
+
+Write-Host ""
+Write-Host "Full data: $outFile"

--- a/provisioners/windows/MDC1Windows/utility_scripts/stress_test/README.md
+++ b/provisioners/windows/MDC1Windows/utility_scripts/stress_test/README.md
@@ -1,0 +1,224 @@
+# MDC1 Windows NUC stress-test toolkit
+
+PowerShell harness for stress-testing, characterizing, and cleaning up after
+workload runs on the wintest2 NUC13 fleet
+(`*.wintest2.releng.mdc1.mozilla.com`).
+
+Built during the [RELOPS-2323](https://mozilla-hub.atlassian.net/browse/RELOPS-2323)
+throttling / perf-degrade investigation in April-May 2026. Latest versions
+of the scripts attached to that ticket as of 2026-05-08.
+
+All scripts are designed to be run from a Windows host with `ssh.exe` and
+`scp.exe` on `PATH` (the Windows OpenSSH client) and an SSH key authorized
+on the target NUCs as `Administrator`. CSVs / transcripts default to
+`C:\logs\` on the driver machine.
+
+## Shared architecture
+
+Every script that hits the fleet uses the same orchestration pattern:
+
+1. Build a self-contained PowerShell diagnostic payload as a here-string,
+   with the **local** variables (e.g. `$duration_secs`) baked in at
+   construction time and **remote** variables backtick-escaped.
+2. Ship the payload via `scp` to the target node's Administrator home dir
+   (avoids the cmd.exe 8191-char limit on `-EncodedCommand`).
+3. Invoke it via `ssh powershell -File <path>`.
+4. Parse one JSON line out of stdout (`Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1`).
+
+Parallelism uses `[RunspaceFactory]::CreateRunspacePool` (not `Start-Job` -
+spawning a child `powershell.exe` per node costs 5-15s on a cold-cache node).
+Log lines from runspaces drain through a `ConcurrentQueue[string]` so output
+stays interleaved cleanly.
+
+A "busy gate" reads `worker-status.json` on each node before doing anything
+destructive - if `currentTaskIds.Count > 0`, the node is skipped so a live CI
+task isn't disturbed.
+
+Retries: 3 sequential SSH retry passes with a 120s sleep between, only on
+nodes that failed (successful nodes don't re-run). Busy-retry passes are
+separate and also bounded.
+
+A shared **skip list** of known-bad PSU / persistent-SSH-failure /
+deployment-failure nodes is duplicated across the fleet scripts to avoid
+wasting cycles on hardware that won't respond. Today the list lives inline
+in each script; if you change it in one place change it everywhere.
+
+## Scripts
+
+### `StressSP3.ps1` - SP3 + Marionette + ETW workload (1150 lines)
+
+The flagship workload. Drives a real Speedometer 3.1 run against Firefox via
+the Marionette protocol over TCP 2828, while capturing ETW power-management
+events. This is what the RELOPS-2323 5-loop fleet sweep used to score every
+node against CI-equivalent load.
+
+Per-node, the remote payload:
+
+1. Self-heals leftover state from any abandoned prior run (kill firefox,
+   stop xperf, unregister `StressSP3_FF_*` scheduled tasks, wipe the
+   workdir). Runs only after the busy gate so a live task is never touched.
+2. Starts an xperf kernel trace (`PROC_THREAD+LOADER+POWER`) and a logman
+   user-mode trace on `Microsoft-Windows-Kernel-Processor-Power`.
+3. Installs Firefox via Chocolatey if not already present (and uninstalls
+   it at the end if-and-only-if this run installed it).
+4. Detects the active interactive user via `query user` and launches
+   Firefox **as that user** through a one-shot scheduled task
+   (`LogonType=Interactive` reuses the existing logon token - no password
+   required). Falls back to Start-Process as Administrator if no task
+   user is logged in.
+5. Runs a hand-rolled Marionette client (Python here-string) that
+   navigates to `https://browserbench.org/Speedometer3.1/`, starts the
+   benchmark, and polls the DOM for `#result-number` / `.score-value` /
+   etc. Loops `-sp3_loops` times in the same Firefox to approximate
+   CI's ~10-min Browsertime cycle window.
+6. Stops ETW, parses the user-mode ETL with `Get-WinEvent -FilterXPath`
+   (FilterXPath is load-bearing - reading all events from a 12-loop ETL
+   would take 10+ min and time out the SSH session).
+7. Runs `xperf -i kernel.etl -a cpufreq` for a frequency-residency summary.
+8. Returns one JSON line with per-loop scores, throttling counters, CPU
+   samples, Firefox launch mode, ETW event counts, and metadata.
+
+Default mode is a 20-node "May 2026 perf-anomaly list" baked into the
+script. Override with `-nodes "a,b,c"`, `-single -node X`, or splat from
+`StressSP3-Fleet.ps1` for a fleet sweep.
+
+### `StressSP3-Fleet.ps1` - fleet-wide SP3 wrapper (150 lines)
+
+Thin wrapper over `StressSP3.ps1` that expands a node range
+(default 1..160), explicit list, or single node, applies the shared skip
+list, and splats forwarded args into `StressSP3.ps1`. All retry / parallel
+/ busy-skip logic lives in the underlying StressSP3 script.
+
+This is the script that produced the 5-loop fleet sweep data
+(`-sp3_loops 5`) referenced in RELOPS-2323 comment 1420888.
+
+Typical invocations:
+
+```powershell
+.\StressSP3-Fleet.ps1                                    # 1-loop sweep, 1..160
+.\StressSP3-Fleet.ps1 -sp3_loops 3 -duration_secs 600    # monthly cadence (~45 min)
+.\StressSP3-Fleet.ps1 -sp3_loops 5                       # degrade-over-loops detection (~75 min)
+.\StressSP3-Fleet.ps1 -range_start 1 -range_end 50       # subset
+.\StressSP3-Fleet.ps1 -nodes "nuc13-077,nuc13-079"       # explicit
+```
+
+### `StressCPU.ps1` - prime95 torture-mode CPU stress (727 lines)
+
+Older heavyweight CPU stress test, complement to the SP3 workload. Runs
+prime95 (`-t` torture mode) for `-duration_secs` per node and captures:
+
+- `% Processor Time` (utilization) min/max/avg + raw samples
+- `% Processor Performance` (achieved frequency, >100=turbo, <100=below
+  nominal - the silicon-throttle fingerprint that pure CPU% can't see)
+- `Microsoft-Windows-Kernel-Processor-Power` Ev37 (firmware CPU limiting)
+  and Ev55 (perf state) events that fired during the stress window
+- prime95 self-test pass/fail counts to detect mid-run instability
+
+Four input modes: `-single -node X`, `-list -nodes a,b,c`,
+`-range -range_start N -range_end M`, `-pool -pool_name <name>`. Pool mode
+pulls `pools.yml` from this repo's `main` branch raw URL.
+
+Downloads prime95 to `C:\prime95\` on the target node if not already
+present. Configures `prime.txt` for all logical cores, FFT range 4-8192,
+hyperthreading on.
+
+### `Scan-NUCHealth.ps1` - fast 10-min triage burner (459 lines)
+
+Per-node ~10-sec single-thread CPU burner sampling
+`% Processor Performance` every second. Captures the brief
+turbo-headroom signature that prompted RELOPS-2323. Per-node fields:
+
+- `Perf_Min/Max/Avg` (full window)
+- `Perf_LateAvg/LateMin` (last 4 samples - exposes thermal/PSU collapse
+  that doesn't show in `Perf_Max`)
+- Power plan, BIOS version/date, CPU base MHz, RAM total, OS build, uptime
+
+Default sweep is 1..160 with the shared skip list applied. 3-pass SSH
+retry. Output: CSV + JSON + transcript in `C:\logs\`, plus a sorted-by-
+lowest-`Perf_Max` console table for triage.
+
+**Recommended cadence:** daily or weekly. The full sweep finishes in
+about 10 min at the default `max_parallel=8`. Per the RELOPS-2323
+analysis, this scan is good triage (catches stuck-low / clear no-turbo)
+but its `r=0.48` correlation with CI Speedometer3 is far weaker than a
+multi-loop StressSP3 sweep (`r=0.84`). Use it for fast scans; use SP3
+for actual workload-tier decisions.
+
+### `Compare-NUCHealth.ps1` - side-by-side diff harness (334 lines)
+
+Pinpoint hardware/firmware/software comparison across a small set of
+nodes (defaults to the 3-node SP3 throttling compare set:
+nuc13-009 / 010 / 029). Returns a side-by-side table on stdout plus a
+full JSON dump in `C:\logs\compare_nuchealth_*.json`.
+
+Captures per-DIMM detail (location, capacity, manufacturer, part number,
+configured vs rated MHz), per-disk media-type/bus/model, power plan +
+processor min/max state, BIOS version/manufacturer/date, OS build,
+uptime, the active interactive task user, and the top 5 processes by
+CPU and working set. Also runs a brief CPU-burner perf sample for
+side-by-side `Perf_Max` comparison.
+
+Use this when you need to ask "what is structurally different between
+this good node and this bad node?"
+
+### `CleanupSP3.ps1` - per-node state reset (77 lines)
+
+Resets state left behind by aborted / timed-out StressSP3 runs. Per
+target node (via SSH as Administrator):
+
+- kills any leftover `firefox.exe`
+- stops any active xperf NT Kernel Logger session
+- stops any leftover logman trace whose name starts with
+  `StressProcPower_`
+- unregisters any scheduled task named `StressSP3_FF_*`
+- deletes `stress_payload_*.ps1` from `C:\Users\Administrator\`
+- deletes the `C:\Users\Public\sp3stress` workdir
+
+Defaults to the 3-node compare set; override with `-nodes "a,b,c"`.
+
+Run this before any new StressSP3 invocation if a previous run was
+killed mid-flight (SSH timeout, Ctrl-C, host reboot). StressSP3 also
+self-heals at the start of each run, but only after its busy gate -
+`CleanupSP3` is the unconditional reset.
+
+### `UninstallFirefox.ps1` - fleet-wide Firefox cleanup (459 lines)
+
+Walks the fleet and uninstalls Firefox installs that StressSP3 may have
+left behind. The default is conservative: only uninstalls Firefox if
+Chocolatey reports it as a managed package
+(`choco list --local-only firefox`). If Firefox was installed by puppet
+or by the base image, `choco` won't claim it and this script leaves it
+alone. Pass `-force` to uninstall regardless.
+
+Why this is needed: StressSP3 installs Firefox via choco only if
+firefox.exe isn't already present, and only uninstalls on the same run
+if that install succeeded. If a run is killed before the uninstall step,
+Firefox can be left installed on the node.
+
+Action matrix: `dry_run` / `absent` / `skipped_not_choco_managed` /
+`skipped_no_choco` / `uninstalled` / `uninstall_failed`. CSV +
+JSON + transcript output to `C:\logs\uninstall_firefox_*`.
+
+## Recommended cadence (from RELOPS-2323 analysis 2026-05-08)
+
+1. **`Scan-NUCHealth.ps1`** - daily / weekly. Fast (~10 min). Triage only.
+2. **`StressSP3-Fleet.ps1 -sp3_loops 3`** - monthly, or after each batch
+   of physical hardware service. Best CI predictor we have
+   (`r=0.84` vs CI Speedometer3). ~45 min wall-clock at `max_parallel=3`.
+3. Reserve **`-sp3_loops 5`** (or higher) for runs where you specifically
+   want to expose degrade-over-loops patterns (the kind that caught
+   nuc13-129 / 131 as thermal degraders that the burner and CI both
+   averaged away).
+
+## Outputs
+
+All scripts write to `C:\logs\` on the driver machine by default. Common
+filename patterns:
+
+| Script                     | Files                                              |
+| -------------------------- | -------------------------------------------------- |
+| `Scan-NUCHealth.ps1`       | `fleet_scan_<N>nodes_<stamp>.{csv,json,log}`       |
+| `StressCPU.ps1`            | `cpu_stress_<tag>_<stamp>.{csv,log}`               |
+| `StressSP3.ps1` (+ fleet)  | `stress_sp3_list-<N>nodes_<stamp>.{csv,log}`       |
+| `Compare-NUCHealth.ps1`    | `compare_nuchealth_<N>nodes_<stamp>.json`          |
+| `UninstallFirefox.ps1`     | `uninstall_firefox_<N>nodes_<stamp>.{csv,json,log}`|

--- a/provisioners/windows/MDC1Windows/utility_scripts/stress_test/Scan-NUCHealth.ps1
+++ b/provisioners/windows/MDC1Windows/utility_scripts/stress_test/Scan-NUCHealth.ps1
@@ -1,0 +1,459 @@
+# Scan-NUCHealth.ps1
+# Fleet-wide scan for the "reduced single-core turbo headroom" pattern that
+# nuc13-029 exhibits (SP3 ~17% slower than healthy peers, brief CPU burner
+# Perf_Max capped near 150% while healthy nodes hit 230%+).
+#
+# Per node:
+#   - busy check (skip if generic-worker has a task running)
+#   - 10-second single-thread CPU burner sampling % Processor Performance
+#   - PerfPct min/avg/max + raw samples
+#   - power plan, BIOS version/date, CPU base MHz, RAM total, OS build, uptime
+#
+# Retries: 3 sequential passes for any node that fails SSH. Failed nodes are
+# retried only - successful nodes don't re-run.
+#
+# Output:
+#   - CSV at C:\logs\fleet_scan_<N>nodes_<stamp>.csv (one row per node)
+#   - Console summary: top suspects sorted by lowest Perf_Max
+#
+# Usage:
+#   .\Scan-NUCHealth.ps1                                           # default 001-160 sweep
+#   .\Scan-NUCHealth.ps1 -range_start 1 -range_end 50              # subset
+#   .\Scan-NUCHealth.ps1 -nodes "nuc13-029,nuc13-066"              # explicit list
+#   .\Scan-NUCHealth.ps1 -max_parallel 4                           # less aggressive parallelism
+#   .\Scan-NUCHealth.ps1 -no_skip                                  # disable skip list
+
+param(
+    [int]$range_start      = 1,
+    [int]$range_end        = 160,
+    [int]$range_pad        = 3,
+    [string]$range_prefix  = "nuc13",
+    [string]$nodes         = "",
+    [string]$ssh_user      = "Administrator",
+    [string]$domain_suffix = "wintest2.releng.mdc1.mozilla.com",
+    [int]$max_parallel     = 8,
+    [int]$ssh_max_retries  = 3,
+    [int]$retry_sleep_secs = 120,
+    [int]$burner_secs      = 10,
+    [int]$top_suspects     = 30,
+    [string]$output_dir    = "C:\logs",
+    [switch]$no_skip,
+    [switch]$dry_run
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ------------------ Skip list (consistent with StressCPU) ------------------
+$skip_nodes = @(
+    "nuc13-035","nuc13-036","nuc13-059","nuc13-060","nuc13-061",
+    "nuc13-068","nuc13-070","nuc13-075","nuc13-096","nuc13-112",
+    "nuc13-130","nuc13-149","nuc13-154","nuc13-155","nuc13-156","nuc13-157",
+    "nuc13-107","nuc13-150"
+)
+
+# ------------------ Resolve target list ------------------
+$target_shorts = @()
+if ($nodes) {
+    $target_shorts = @($nodes -split '[,\s]+' | Where-Object { $_ } | ForEach-Object { ($_ -replace '\..*$', '').Trim() })
+} else {
+    $target_shorts = $range_start..$range_end | ForEach-Object {
+        "{0}-{1:D$range_pad}" -f $range_prefix, $_
+    }
+}
+
+if (-not $no_skip) {
+    $before = $target_shorts.Count
+    $target_shorts = @($target_shorts | Where-Object { $skip_nodes -notcontains $_ })
+    $skipped = $before - $target_shorts.Count
+    if ($skipped -gt 0) {
+        Write-Host "Skipping $skipped known-problem node(s)." -ForegroundColor Yellow
+    }
+}
+
+if ($target_shorts.Count -eq 0) { Write-Error "No nodes to scan."; exit 1 }
+
+$targets = @($target_shorts | ForEach-Object { "$_.$domain_suffix" })
+
+# ------------------ Output paths ------------------
+$stamp   = (Get-Date).ToString('yyyyMMdd_HHmmss')
+if (-not (Test-Path $output_dir)) { New-Item -ItemType Directory $output_dir -Force | Out-Null }
+$logFile = Join-Path $output_dir ("fleet_scan_{0}nodes_{1}.log" -f $targets.Count, $stamp)
+$csvFile = Join-Path $output_dir ("fleet_scan_{0}nodes_{1}.csv" -f $targets.Count, $stamp)
+$jsonFile= Join-Path $output_dir ("fleet_scan_{0}nodes_{1}.json" -f $targets.Count, $stamp)
+
+Start-Transcript -Path $logFile -Append | Out-Null
+
+Write-Host ""
+Write-Host "------------------------------------------------------------"
+Write-Host "  Scan-NUCHealth fleet sweep"
+Write-Host "  Nodes      : $($targets.Count) (range $range_start..$range_end)"
+Write-Host "  Parallel   : $max_parallel"
+Write-Host "  Retries    : up to $ssh_max_retries SSH retry passes"
+Write-Host "  Burner     : ${burner_secs}s per node"
+Write-Host "  User       : $ssh_user"
+Write-Host "  Skip list  : $(if ($no_skip) { 'disabled' } else { "$($skip_nodes.Count) nodes" })"
+Write-Host "  CSV        : $csvFile"
+Write-Host "------------------------------------------------------------"
+Write-Host ""
+
+# ------------------ Remote diagnostic payload ------------------
+$diagPayload = @"
+`$ErrorActionPreference = 'Continue'
+
+# --- Busy check (skip if generic-worker has a task) ---
+`$wsp = `$null
+foreach (`$p in @("C:\WINDOWS\SystemTemp", `$env:TMP, `$env:TEMP, `$env:USERPROFILE)) {
+    if (`$p) { `$c = Join-Path `$p "worker-status.json"; if (Test-Path `$c) { `$wsp = `$c; break } }
+}
+`$busy = `$false
+if (`$wsp) {
+    try { `$j = Get-Content `$wsp -Raw | ConvertFrom-Json; if (@(`$j.currentTaskIds).Count -gt 0) { `$busy = `$true } } catch {}
+}
+if (`$busy) {
+    [pscustomobject]@{ Status='busy'; Hostname=`$env:COMPUTERNAME } | ConvertTo-Json -Compress
+    return
+}
+
+# --- Power plan + min/max state ---
+`$pwrSchemeOut = & powercfg /getactivescheme 2>`$null
+`$pwrPlan = if (`$pwrSchemeOut -match 'GUID:\s+[a-f0-9-]+\s+\((.+)\)') { `$matches[1] } else { 'unknown' }
+
+# --- CPU info ---
+`$cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+`$cpuName = `$cpu.Name
+`$cpuMaxMHz = `$cpu.MaxClockSpeed
+
+# --- Achieved %Performance under brief load ---
+# Use an inline runspace (not Start-Job) for the CPU burner: Start-Job spawns a
+# whole child powershell.exe which can take 5-15s to initialize on a cold-cache
+# node. Runspaces start in <100ms.
+`$burnerSecs = $burner_secs
+`$perfSamples = @()
+`$burnerRunspace = [runspacefactory]::CreateRunspace()
+`$burnerRunspace.Open()
+`$burnerPS = [powershell]::Create()
+`$burnerPS.Runspace = `$burnerRunspace
+[void]`$burnerPS.AddScript({
+    param(`$secs)
+    `$end = (Get-Date).AddSeconds(`$secs + 1)
+    while ((Get-Date) -lt `$end) { `$x = 0; for (`$i=0; `$i -lt 1000000; `$i++) { `$x = `$x + `$i } }
+}).AddArgument(`$burnerSecs)
+`$burnerHandle = `$burnerPS.BeginInvoke()
+Start-Sleep -Milliseconds 300
+for (`$s = 0; `$s -lt `$burnerSecs; `$s++) {
+    try {
+        `$ctr = (Get-Counter '\Processor Information(_Total)\% Processor Performance' -ErrorAction Stop).CounterSamples[0].CookedValue
+        `$perfSamples += [math]::Round(`$ctr, 1)
+    } catch {}
+    Start-Sleep -Milliseconds 900
+}
+try { `$burnerPS.Stop() } catch {}
+try { `$burnerPS.Dispose() } catch {}
+try { `$burnerRunspace.Close(); `$burnerRunspace.Dispose() } catch {}
+
+`$perfMax = if (`$perfSamples.Count -gt 0) { (`$perfSamples | Measure-Object -Maximum).Maximum } else { `$null }
+`$perfMin = if (`$perfSamples.Count -gt 0) { (`$perfSamples | Measure-Object -Minimum).Minimum } else { `$null }
+`$perfAvg = if (`$perfSamples.Count -gt 0) { [math]::Round((`$perfSamples | Measure-Object -Average).Average, 1) } else { `$null }
+# Late-window samples (after the CPU has warmed) - exposes thermal/PSU collapse
+`$lateSamples = @()
+if (`$perfSamples.Count -ge 4) { `$lateSamples = `$perfSamples[(`$perfSamples.Count - 4)..(`$perfSamples.Count - 1)] }
+`$perfLateAvg = if (`$lateSamples.Count -gt 0) { [math]::Round((`$lateSamples | Measure-Object -Average).Average, 1) } else { `$null }
+`$perfLateMin = if (`$lateSamples.Count -gt 0) { (`$lateSamples | Measure-Object -Minimum).Minimum } else { `$null }
+
+# --- RAM ---
+`$ramDimms = @(Get-CimInstance Win32_PhysicalMemory)
+`$ramTotalGB = [math]::Round((`$ramDimms | Measure-Object -Property Capacity -Sum).Sum / 1GB, 1)
+`$ramSpeed = (`$ramDimms | ForEach-Object { `$_.ConfiguredClockSpeed } | Sort-Object -Unique) -join '/'
+
+# --- BIOS ---
+`$bios = Get-CimInstance Win32_BIOS
+`$biosVer = `$bios.SMBIOSBIOSVersion
+`$biosDate = if (`$bios.ReleaseDate) { (`$bios.ReleaseDate).ToString('yyyy-MM-dd') } else { '?' }
+
+# --- OS / uptime ---
+`$os = Get-CimInstance Win32_OperatingSystem
+`$osBuild = `$os.BuildNumber
+`$uptimeMin = [int]((Get-Date) - `$os.LastBootUpTime).TotalMinutes
+
+[pscustomobject]@{
+    Status        = 'ok'
+    Hostname      = `$env:COMPUTERNAME
+    Timestamp     = (Get-Date).ToString('s')
+    PowerPlan     = `$pwrPlan
+    CPU           = `$cpuName
+    CPU_MaxMHz    = `$cpuMaxMHz
+    Perf_Max      = `$perfMax
+    Perf_Avg      = `$perfAvg
+    Perf_Min      = `$perfMin
+    Perf_LateAvg  = `$perfLateAvg
+    Perf_LateMin  = `$perfLateMin
+    Perf_Samples  = `$perfSamples -join ','
+    RAM_GB        = `$ramTotalGB
+    RAM_MHz       = `$ramSpeed
+    BIOS_Version  = `$biosVer
+    BIOS_Date     = `$biosDate
+    OS_Build      = `$osBuild
+    Uptime_Min    = `$uptimeMin
+} | ConvertTo-Json -Depth 5 -Compress
+"@
+
+# ------------------ Per-node helper (scp + ssh -File) ------------------
+$rsScript = {
+    param(
+        [string]$Fqdn,
+        [string]$User,
+        [string]$Payload,
+        [System.Collections.Concurrent.ConcurrentQueue[string]]$MsgQueue
+    )
+
+    function Log { param([string]$Msg) $MsgQueue.Enqueue($Msg) }
+    $short = ($Fqdn -split '\.')[0]
+    Log "[$short] start"
+
+    $remoteName = "scan_nuchealth_$([guid]::NewGuid().ToString('N')).ps1"
+    $localTemp  = Join-Path $env:TEMP $remoteName
+    Set-Content -Path $localTemp -Value $Payload -Encoding UTF8
+
+    try {
+        $scpArgs = "-O -o ConnectTimeout=10 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no `"$localTemp`" `"${User}@${Fqdn}:$remoteName`""
+        $psi = [System.Diagnostics.ProcessStartInfo]::new('scp')
+        $psi.Arguments              = $scpArgs
+        $psi.UseShellExecute        = $false
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError  = $true
+        $psi.CreateNoWindow         = $true
+        $sp = [System.Diagnostics.Process]::Start($psi)
+        $sp.StandardOutput.ReadToEnd() | Out-Null
+        $scpErr = $sp.StandardError.ReadToEnd()
+        $exited = $sp.WaitForExit(25000)
+        if (-not $exited) { try { $sp.Kill() } catch {}; return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="scp timeout" } }
+        $scpExit = $sp.ExitCode
+        $sp.Dispose()
+        if ($scpExit -ne 0) {
+            return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="scp exit $scpExit : $scpErr" }
+        }
+
+        Log "[$short] running diag"
+        # Use absolute Administrator home path (no $env or %% expansion needed) so the
+        # command parses identically whether the remote default shell is PowerShell
+        # or cmd.exe. Drop the trailing "; Remove-Item ..." (which CRT argv parsing
+        # would concatenate onto the path arg as a literal ";") - we accept the
+        # leftover ~2KB scan_nuchealth_*.ps1 in C:\Users\Administrator\ for now;
+        # CleanupSP3.ps1 covers stress_payload_*.ps1 and a similar sweep can clean
+        # these scan files later if needed.
+        $remoteCmd = "powershell -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File C:\Users\Administrator\$remoteName"
+        $sshArgs = "-o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no ${User}@${Fqdn} $remoteCmd"
+        $psi2 = [System.Diagnostics.ProcessStartInfo]::new('ssh')
+        $psi2.Arguments              = $sshArgs
+        $psi2.UseShellExecute        = $false
+        $psi2.RedirectStandardOutput = $true
+        $psi2.RedirectStandardError  = $true
+        $psi2.CreateNoWindow         = $true
+        $sp2 = [System.Diagnostics.Process]::Start($psi2)
+        $stdout = $sp2.StandardOutput.ReadToEnd()
+        $stderr = $sp2.StandardError.ReadToEnd()
+        $exited2 = $sp2.WaitForExit(60000)
+        if (-not $exited2) { try { $sp2.Kill() } catch {}; return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="ssh timeout" } }
+        $sshExit = $sp2.ExitCode
+        $sp2.Dispose()
+        if ($sshExit -ne 0) {
+            return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="ssh exit $sshExit : $stderr" }
+        }
+
+        $jsonLine = ($stdout -split "`n") | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        if (-not $jsonLine) {
+            return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="no JSON in stdout" }
+        }
+        try {
+            $obj = $jsonLine | ConvertFrom-Json
+        } catch {
+            return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="JSON parse: $_" }
+        }
+
+        if ($obj.Status -eq 'busy') {
+            return [pscustomobject]@{ _s='busy'; Fqdn=$Fqdn; Hostname=$obj.Hostname }
+        }
+
+        return [pscustomobject]@{ _s='ok'; Fqdn=$Fqdn; Data=$obj }
+    } finally {
+        Remove-Item $localTemp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ------------------ Parallel runner ------------------
+function Invoke-ScanBatch {
+    param([string[]]$Fqdns, [int]$Parallel)
+
+    $rsPool = [RunspaceFactory]::CreateRunspacePool(1, [math]::Max(1, $Parallel))
+    $rsPool.Open()
+    $msgQueue = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
+
+    function Drain-Queue {
+        $msg = $null
+        while ($msgQueue.TryDequeue([ref]$msg)) { Write-Host $msg; $msg = $null }
+    }
+
+    $totalBatches = [math]::Ceiling($Fqdns.Count / $Parallel)
+    $batchNum = 0
+    $batchResults = @{}
+
+    for ($i = 0; $i -lt $Fqdns.Count; $i += $Parallel) {
+        $batchNum++
+        $batch = $Fqdns[$i..[math]::Min($i + $Parallel - 1, $Fqdns.Count - 1)]
+        Write-Host ("  Batch {0}/{1} : {2} node(s)" -f $batchNum, $totalBatches, $batch.Count)
+
+        $jobs = [System.Collections.Generic.List[object]]::new()
+        foreach ($fqdn in $batch) {
+            $ps = [PowerShell]::Create()
+            $ps.RunspacePool = $rsPool
+            [void]$ps.AddScript($rsScript)
+            [void]$ps.AddParameters(@{ Fqdn=$fqdn; User=$ssh_user; Payload=$diagPayload; MsgQueue=$msgQueue })
+            $jobs.Add([pscustomobject]@{ PS=$ps; Handle=$ps.BeginInvoke(); Fqdn=$fqdn })
+        }
+
+        $pending = [System.Collections.Generic.List[object]]::new($jobs)
+        $lastHB = [datetime]::Now
+        while ($pending.Count -gt 0) {
+            Drain-Queue
+            if (([datetime]::Now - $lastHB).TotalSeconds -ge 30) {
+                Write-Host ("    [waiting] {0} node(s) still in this batch..." -f $pending.Count)
+                $lastHB = [datetime]::Now
+            }
+            $done = @($pending | Where-Object { $_.Handle.IsCompleted })
+            foreach ($job in $done) {
+                [void]$pending.Remove($job)
+                try { $r = $job.PS.EndInvoke($job.Handle)[0] }
+                catch { $r = [pscustomobject]@{ _s='ssherr'; Fqdn=$job.Fqdn; Reason="runspace error: $_" } }
+                $job.PS.Dispose()
+                $batchResults[$job.Fqdn] = $r
+                $short = ($job.Fqdn -split '\.')[0]
+                $msg = switch ($r._s) {
+                    'ok'     { "[$short] ok  Perf_Max=$($r.Data.Perf_Max)  Perf_LateAvg=$($r.Data.Perf_LateAvg)" }
+                    'busy'   { "[$short] busy (skipped)" }
+                    'ssherr' { "[$short] SSH/diag failed: $($r.Reason)" }
+                    default  { "[$short] unknown state" }
+                }
+                Write-Host $msg
+            }
+            if ($pending.Count -gt 0) { Start-Sleep -Milliseconds 250 }
+        }
+        Drain-Queue
+    }
+
+    $rsPool.Close()
+    $rsPool.Dispose()
+    return $batchResults
+}
+
+if ($dry_run) {
+    Write-Host "DRY RUN: would scan $($targets.Count) node(s)."
+    $target_shorts | ForEach-Object { Write-Host "  $_" }
+    Stop-Transcript | Out-Null
+    return
+}
+
+# ------------------ PASS 1 ------------------
+Write-Host ""
+Write-Host "==== PASS 1 ===="
+$results = @{}
+$pass1 = Invoke-ScanBatch -Fqdns $targets -Parallel $max_parallel
+foreach ($k in $pass1.Keys) { $results[$k] = $pass1[$k] }
+
+# ------------------ Retry passes ------------------
+$pass = 1
+while ($pass -le $ssh_max_retries) {
+    $failed = @($results.GetEnumerator() | Where-Object { $_.Value._s -eq 'ssherr' } | ForEach-Object { $_.Key })
+    if ($failed.Count -eq 0) { break }
+    Write-Host ""
+    Write-Host ("---- Sleeping {0}s : SSH retry {1} of {2} - {3} node(s) ----" -f $retry_sleep_secs, $pass, $ssh_max_retries, $failed.Count)
+    Start-Sleep -Seconds $retry_sleep_secs
+    Write-Host ""
+    Write-Host ("==== RETRY PASS {0} ({1} node(s)) ====" -f $pass, $failed.Count)
+    $r = Invoke-ScanBatch -Fqdns $failed -Parallel $max_parallel
+    foreach ($k in $r.Keys) { $results[$k] = $r[$k] }
+    $pass++
+}
+
+# ------------------ Build CSV rows ------------------
+$rows = foreach ($fqdn in $targets) {
+    $short = ($fqdn -split '\.')[0]
+    $r = if ($results.ContainsKey($fqdn)) { $results[$fqdn] } else { [pscustomobject]@{ _s='ssherr'; Reason='not attempted' } }
+    if ($r._s -eq 'ok' -and $r.Data) {
+        $d = $r.Data
+        [pscustomobject]@{
+            Hostname     = $short
+            Status       = 'ok'
+            Perf_Max     = $d.Perf_Max
+            Perf_Avg     = $d.Perf_Avg
+            Perf_Min     = $d.Perf_Min
+            Perf_LateAvg = $d.Perf_LateAvg
+            Perf_LateMin = $d.Perf_LateMin
+            Perf_Samples = $d.Perf_Samples
+            CPU_MaxMHz   = $d.CPU_MaxMHz
+            PowerPlan    = $d.PowerPlan
+            RAM_GB       = $d.RAM_GB
+            RAM_MHz      = $d.RAM_MHz
+            BIOS_Version = $d.BIOS_Version
+            BIOS_Date    = $d.BIOS_Date
+            OS_Build     = $d.OS_Build
+            Uptime_Min   = $d.Uptime_Min
+            Timestamp    = $d.Timestamp
+            Note         = ''
+        }
+    } elseif ($r._s -eq 'busy') {
+        [pscustomobject]@{ Hostname=$short; Status='busy'; Note='worker had a task' }
+    } else {
+        [pscustomobject]@{ Hostname=$short; Status='ssh_failed'; Note=($r.Reason -replace "`r`n",' ' -replace "\s+", ' ') }
+    }
+}
+
+$rows | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+$results | ConvertTo-Json -Depth 6 | Set-Content -Path $jsonFile -Encoding UTF8
+
+# ------------------ Summary ------------------
+$ok      = @($rows | Where-Object { $_.Status -eq 'ok' })
+$busy    = @($rows | Where-Object { $_.Status -eq 'busy' })
+$failed  = @($rows | Where-Object { $_.Status -eq 'ssh_failed' })
+
+Write-Host ""
+Write-Host "============================================================"
+Write-Host "  SUMMARY"
+Write-Host "============================================================"
+Write-Host ("  Scanned       : {0}" -f $rows.Count)
+Write-Host ("  Successful    : {0}" -f $ok.Count)
+Write-Host ("  Busy (skip)   : {0}" -f $busy.Count)
+Write-Host ("  Failed (ssh)  : {0}  (after $ssh_max_retries retries)" -f $failed.Count)
+Write-Host ""
+
+if ($ok.Count -gt 0) {
+    Write-Host "==== TOP $top_suspects SUSPECTS (lowest Perf_Max - possible reduced turbo headroom) ===="
+    $ok |
+        Sort-Object @{e={[double]$_.Perf_Max}; ascending=$true} |
+        Select-Object -First $top_suspects |
+        Format-Table Hostname, Perf_Max, Perf_Avg, Perf_Min, Perf_LateAvg, Perf_LateMin, BIOS_Version, BIOS_Date, Uptime_Min -AutoSize |
+        Out-String | Write-Host
+
+    $maxAll = ($ok | ForEach-Object { [double]$_.Perf_Max } | Measure-Object -Maximum).Maximum
+    $avgAll = [math]::Round(($ok | ForEach-Object { [double]$_.Perf_Max } | Measure-Object -Average).Average, 1)
+    $minAll = ($ok | ForEach-Object { [double]$_.Perf_Max } | Measure-Object -Minimum).Minimum
+    Write-Host ("Fleet Perf_Max  min={0}  avg={1}  max={2}" -f $minAll, $avgAll, $maxAll)
+}
+
+if ($busy.Count -gt 0) {
+    Write-Host ""
+    Write-Host "==== BUSY (skipped) ===="
+    $busy | ForEach-Object { Write-Host ("  {0}" -f $_.Hostname) }
+}
+
+if ($failed.Count -gt 0) {
+    Write-Host ""
+    Write-Host "==== FAILED (after retries) ===="
+    $failed | ForEach-Object { Write-Host ("  {0}  -- {1}" -f $_.Hostname, $_.Note) }
+}
+
+Write-Host ""
+Write-Host "Log : $logFile"
+Write-Host "CSV : $csvFile"
+Write-Host "JSON: $jsonFile"
+Stop-Transcript | Out-Null

--- a/provisioners/windows/MDC1Windows/utility_scripts/stress_test/StressCPU.ps1
+++ b/provisioners/windows/MDC1Windows/utility_scripts/stress_test/StressCPU.ps1
@@ -1,0 +1,727 @@
+# StressCPU.ps1
+# SSH-based prime95 torture-mode CPU stress test + throttling probe across NUC13 nodes.
+#
+# Runs prime95 (-t torture mode) for $duration_secs on each node and captures:
+#   - CPU utilization (% Processor Time) min/max/avg + raw samples
+#   - Achieved frequency (% Processor Performance) min/max/avg + raw samples
+#     (>100 means turbo, <100 means CPU is below nominal - the silicon-throttle
+#     fingerprint that pure CPU% cannot detect; added 2026-05-07 during the
+#     RELOPS-2323 throttling investigation)
+#   - Microsoft-Windows-Kernel-Processor-Power Ev37 (firmware CPU limiting)
+#     and Ev55 (perf state) events that fired during the stress window
+#   - prime95 self-test pass/fail counts to detect mid-run instability
+#
+# Modes:
+#   -single -node nuc13-XXX           one node
+#   -list -nodes "n1,n2,n3"           explicit list
+#   -range -range_start N -range_end M     contiguous range
+#   -pool -pool_name <name>           pool defined in pools.yml
+#   -parallel                         run a batch concurrently (max_parallel)
+#
+# Login user: -ssh_user (defaults to Administrator for the wintest2 fleet).
+# Output: CSV + transcript log in $output_dir (default C:\logs).
+# Skip list: known-bad PSU nodes are auto-excluded from range/pool scans.
+#
+# Used in the RELOPS-2323 throttling investigation as the heavy multi-core
+# stress test, complementing the lighter Compare-NUCHealth/Scan-NUCHealth burner.
+
+param(
+    [switch]$single,
+    [switch]$pool,
+    [switch]$range,
+    [switch]$list,
+    [string]$node,
+    [string]$pool_name,
+    [string[]]$nodes = @(),
+
+    # Range mode
+    [string]$range_prefix  = "nuc13",
+    [int]$range_start      = 1,
+    [int]$range_end        = 160,
+    [int]$range_pad        = 3,
+
+    # Environment
+    [string]$domain_suffix = "wintest2.releng.mdc1.mozilla.com",
+    [string]$yaml_url      = "https://raw.githubusercontent.com/mozilla-platform-ops/worker-images/refs/heads/main/provisioners/windows/MDC1Windows/pools.yml",
+    [string]$ssh_user      = "Administrator",
+
+    # Stress parameters
+    [int]$duration_secs    = 180,
+    [int]$retry_sleep_secs = 120,
+    [int]$ssh_max_retries  = 3,
+    [switch]$quick,
+
+    # Output
+    [string]$output_dir    = "C:\logs",
+    [string]$output_name   = "",
+
+    # Parallel execution
+    [switch]$parallel,
+    [int]$max_parallel  = 3,
+
+    [switch]$dry_run,
+    [switch]$no_retry,
+    [switch]$help
+)
+
+if ($quick) { $duration_secs = 30; $retry_sleep_secs = 10 }
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:stamp           = (Get-Date).ToString("yyyyMMdd_HHmmss")
+$script:failed_ssh      = @()
+$script:retry_recovered = @()
+$script:busy_nodes      = @()
+$script:results         = @()
+
+# ------------------ Helpers ------------------
+function Ensure-Dir {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { New-Item -ItemType Directory -Path $Path -Force | Out-Null }
+}
+
+function Sleep-BetweenPasses {
+    param([int]$Seconds, [string]$Label = "")
+    Write-Host ""
+    Write-Host ("---- Sleeping {0}s{1} ----" -f $Seconds, $(if ($Label) { " : $Label" } else { "" }))
+    Start-Sleep -Seconds $Seconds
+    Write-Host ""
+}
+
+function Invoke-SSH {
+    param([Parameter(Mandatory)][string]$NodeName, [Parameter(Mandatory)][string]$Command, [int]$TimeoutSec = 300)
+    $target = if ($NodeName -match '@') { $NodeName } else { "$ssh_user@$NodeName" }
+    $psi = [System.Diagnostics.ProcessStartInfo]::new('ssh')
+    $psi.Arguments              = "-o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no $target $Command"
+    $psi.UseShellExecute        = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.CreateNoWindow         = $true
+    $p       = [System.Diagnostics.Process]::Start($psi)
+    $outTask = $p.StandardOutput.ReadToEndAsync()
+    $errTask = $p.StandardError.ReadToEndAsync()
+    $exited  = $p.WaitForExit($TimeoutSec * 1000)
+    if (-not $exited) { try { $p.Kill() } catch {} }
+    $null = $outTask.Wait(10000)
+    $null = $errTask.Wait(10000)
+    $stdout   = if ($outTask.Status -eq 'RanToCompletion') { $outTask.Result } else { '' }
+    $exitCode = if ($exited) { $p.ExitCode } else { 255 }
+    $p.Dispose()
+    [pscustomobject]@{ Output = $stdout; ExitCode = $exitCode }
+}
+
+function Encode-PSCommand {
+    param([Parameter(Mandatory)][string]$Command)
+    $pref = @"
+`$ProgressPreference='SilentlyContinue';
+`$VerbosePreference='SilentlyContinue';
+`$InformationPreference='SilentlyContinue';
+`$WarningPreference='SilentlyContinue';
+"@
+    $full  = "$pref $Command"
+    $bytes = [System.Text.Encoding]::Unicode.GetBytes($full)
+    [Convert]::ToBase64String($bytes)
+}
+
+function Invoke-SSHPS {
+    param([Parameter(Mandatory)][string]$NodeName, [Parameter(Mandatory)][string]$PsCommand)
+    $enc = Encode-PSCommand -Command $PsCommand
+    Invoke-SSH -NodeName $NodeName -TimeoutSec ($duration_secs + 90) -Command ("powershell -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -EncodedCommand $enc")
+}
+
+# ------------------ CLI UX ------------------
+if (-not $single -and -not $pool -and -not $range -and -not $list -and -not $help) {
+    $choice = Read-Host "No mode selected.`n'1' single node`n'2' pool (YAML)`n'3' range (nuc13-001..160)`n'4' explicit node list`n'5' help`n'q' quit`n"
+    switch ($choice) {
+        '1' { $single = $true }
+        '2' { $pool   = $true }
+        '3' { $range  = $true }
+        '4' { $list   = $true }
+        '5' { $help   = $true }
+        'q' { Write-Host "Exiting."; exit }
+        default { $help = $true }
+    }
+}
+
+if ($help) {
+@"
+Usage: StressCPU.ps1 -range|-single|-pool|-list [options]
+
+Modes:
+  -range                          nuc13-001 through nuc13-160 (no YAML needed)
+  -single -node <name>            single node by short name
+  -pool   -pool_name <name>       all nodes in a pool (from YAML)
+  -list   -nodes <n1,n2,...>      explicit comma-separated list of short names
+
+Range options:
+  -range_prefix <str>        node name prefix  (default: nuc13)
+  -range_start  <n>          first node number (default: 1)
+  -range_end    <n>          last node number  (default: 160)
+  -range_pad    <n>          zero-pad width    (default: 3 -> nuc13-001)
+
+Stress options:
+  -duration_secs <n>         stress duration per node in seconds (default: 120)
+  -quick                     shortcut: duration=30s, retry_sleep=10s
+
+Retry options:
+  -retry_sleep_secs <n>      seconds between retries (default: 120)
+  -ssh_max_retries  <n>      max SSH-failure retry attempts (default: 3)
+
+Output options:
+  -output_dir  <path>        directory for CSV and log (default: C:\logs)
+  -output_name <file.csv>    optional filename override
+  -parallel                  run nodes concurrently instead of one at a time
+  -max_parallel <n>          nodes per batch when using -parallel (default: 3)
+  -dry_run                   print actions; do not SSH
+  -no_retry                  skip busy and SSH retry loops (one pass only)
+
+Examples:
+  .\StressCPU.ps1 -range
+  .\StressCPU.ps1 -range -duration_secs 300 -range_start 50 -range_end 100
+  .\StressCPU.ps1 -single -node nuc13-077 -duration_secs 300
+  .\StressCPU.ps1 -range -quick
+  .\StressCPU.ps1 -list -nodes nuc13-024,nuc13-033,nuc13-042 -parallel
+  .\StressCPU.ps1 -list -nodes nuc13-024,nuc13-033,nuc13-042 -parallel -duration_secs 900
+"@ | Write-Host
+    exit
+}
+
+# ------------------ Resolve targets ------------------
+$targets = @()
+
+if ($range) {
+    if ($range_start -gt $range_end) { Write-Host "range_start > range_end. Exiting."; exit 1 }
+    $targets = $range_start..$range_end |
+        ForEach-Object { ("{0}-{1}" -f $range_prefix, $_.ToString("D$range_pad")) + ".$domain_suffix" }
+    Write-Host ("Range: {0}-{1} through {0}-{2}  ({3} nodes)" -f
+        $range_prefix,
+        $range_start.ToString("D$range_pad"),
+        $range_end.ToString("D$range_pad"),
+        $targets.Count)
+} elseif ($list) {
+    if ($nodes.Count -eq 0) { Write-Host "No nodes provided. Use: -list -nodes nuc13-024,nuc13-033,..."; exit 1 }
+    $targets = $nodes | ForEach-Object {
+        $n = $_.Trim().ToLower() -replace ',', ''
+        if ($n -notlike "*.*") { "$n.$domain_suffix" } else { $n }
+    }
+    Write-Host ("List mode: {0} node(s): {1}" -f $targets.Count, ($targets -join ', '))
+} else {
+    Write-Host "Pulling pool data from $yaml_url"
+    $YAML = Invoke-WebRequest -Uri $yaml_url | ConvertFrom-Yaml
+
+    if ($single) {
+        if ([string]::IsNullOrWhiteSpace($node)) {
+            $node = Read-Host "Node name"
+            if ([string]::IsNullOrWhiteSpace($node)) { Write-Host "No node provided. Exiting."; exit }
+        }
+        $found = $false
+        foreach ($wp in $YAML.pools) { if ($wp.nodes -contains $node) { $found = $true; break } }
+        if (-not $found) { Write-Host "Node '$node' not found in YAML."; exit 96 }
+        $targets = @("$node.$domain_suffix")
+    } elseif ($pool) {
+        if ([string]::IsNullOrWhiteSpace($pool_name)) {
+            Write-Host "Available pools:"; $YAML.pools | ForEach-Object { Write-Host "  $($_.name)" }
+            $pool_name = Read-Host "Pool name"
+            if ([string]::IsNullOrWhiteSpace($pool_name)) { Write-Host "No pool provided. Exiting."; exit }
+        }
+        if (@($YAML.pools.name) -notcontains $pool_name) { Write-Host "'$pool_name' not a valid pool."; exit 97 }
+        $targets = ($YAML.pools | Where-Object { $_.name -eq $pool_name }).nodes |
+            ForEach-Object { "$_.$domain_suffix" }
+    }
+}
+
+# ------------------ Skip known-problem nodes ------------------
+$script:skip_nodes = @(
+    # Bad PSU — will not recover without hardware replacement (went down within last 14 days as of 2026-04-22)
+    "nuc13-035","nuc13-036","nuc13-059","nuc13-060","nuc13-061",
+    "nuc13-068","nuc13-070","nuc13-075","nuc13-096","nuc13-112",
+    "nuc13-024",  # persistent SSH failure across all runs — assumed bad PSU
+    "nuc13-130","nuc13-149","nuc13-154","nuc13-155","nuc13-156","nuc13-157",
+    # Known bad — other causes
+    "nuc13-107",  # permanent deployment failure
+    "nuc13-150"   # other issue
+)
+
+$_skipped_targets = @($targets | Where-Object {
+    $short = ($_ -split '\.')[0].ToLower()
+    $script:skip_nodes -contains $short
+})
+if ($_skipped_targets.Count -gt 0) {
+    $_skipped_shorts = $_skipped_targets | ForEach-Object { ($_ -split '\.')[0].ToLower() }
+    if ($single) {
+        Write-Host ("WARNING: {0} is on the known-problem skip list. Proceeding anyway (single mode)." -f ($_skipped_shorts -join ', ')) -ForegroundColor Yellow
+    } else {
+        Write-Host ("Skipping {0} known-problem node(s): {1}" -f $_skipped_targets.Count, ($_skipped_shorts -join ', ')) -ForegroundColor Yellow
+        $targets = @($targets | Where-Object {
+            $short = ($_ -split '\.')[0].ToLower()
+            $script:skip_nodes -notcontains $short
+        })
+    }
+}
+
+# ------------------ Start transcript ------------------
+Ensure-Dir -Path $output_dir
+
+$script:tag = if ($range)        { "{0}-{1}-{2}" -f $range_prefix, $range_start.ToString("D$range_pad"), $range_end.ToString("D$range_pad") }
+              elseif ($single)   { $node }
+              elseif ($pool)     { $pool_name }
+              elseif ($list)     { "list-{0}nodes" -f $targets.Count }
+              else               { "unknown" }
+
+if (-not [string]::IsNullOrWhiteSpace($output_name)) {
+    $script:tag = [System.IO.Path]::GetFileNameWithoutExtension($output_name)
+}
+
+$logFile = Join-Path $output_dir ("cpu_stress_{0}_{1}.log" -f $script:tag, $script:stamp)
+Start-Transcript -Path $logFile -Append
+Write-Host "Log : $logFile"
+Write-Host ""
+
+# ------------------ Remote payload ------------------
+# Local variables (baked in at encode time): $duration_secs
+# Remote variables (escaped with backtick): everything else
+$stressPayload = @"
+`$ErrorActionPreference='Stop'
+Set-StrictMode -Version Latest
+
+`$wsp=`$null
+foreach(`$p in @("C:\WINDOWS\SystemTemp",`$env:TMP,`$env:TEMP,`$env:USERPROFILE)){
+    if(`$p){`$c=Join-Path `$p "worker-status.json";if(Test-Path `$c){`$wsp=`$c;break}}
+}
+`$busy=`$false
+if(`$wsp){
+    try{`$j=Get-Content `$wsp -Raw|ConvertFrom-Json;if(@(`$j.currentTaskIds).Count -gt 0){`$busy=`$true}}catch{}
+}
+
+if(`$busy){
+    [pscustomobject]@{Status='busy';Hostname=`$env:COMPUTERNAME}|ConvertTo-Json -Compress
+}else{
+    `$p95dir='C:\prime95'
+    `$p95exe=Join-Path `$p95dir 'prime95.exe'
+    if(-not(Test-Path `$p95dir)){New-Item -ItemType Directory -Path `$p95dir -Force|Out-Null}
+    if(-not(Test-Path `$p95exe)){
+        `$zip=Join-Path `$p95dir 'p95.zip'
+        Invoke-WebRequest -Uri 'https://roninpuppetassets.blob.core.windows.net/binaries/p95v3019b20.win64(1).zip' -OutFile `$zip -UseBasicParsing
+        Expand-Archive -Path `$zip -DestinationPath `$p95dir -Force
+        Remove-Item `$zip -Force -ErrorAction SilentlyContinue
+    }
+
+    `$nc=[Environment]::ProcessorCount
+    `$dur=$duration_secs
+
+    @("V24OptionsConverted=1","WGUID_version=2","StressTester=1","UsePrimenet=0",
+      "MinTortureFFT=4","MaxTortureFFT=8192","TortureMem=50","TortureTime=1",
+      "TortureHyperthreading=1","V30OptionsConverted=1","NumWorkers=`$nc")-join "`r`n"|Set-Content (Join-Path `$p95dir 'prime.txt') -Encoding ASCII
+
+    `$rf=Join-Path `$p95dir 'results.txt'
+    Remove-Item `$rf -Force -ErrorAction SilentlyContinue
+
+    `$t0=Get-Date
+    `$proc=Start-Process -FilePath `$p95exe -ArgumentList '-t' -WorkingDirectory `$p95dir -WindowStyle Hidden -PassThru
+    Start-Sleep -Seconds 5
+    `$p95Started=-not `$proc.HasExited
+    `$cpuSamples =[System.Collections.Generic.List[double]]::new()
+    `$perfSamples=[System.Collections.Generic.List[double]]::new()
+    if(`$p95Started){
+        `$deadline=`$t0.AddSeconds(`$dur-2)
+        while((Get-Date) -lt `$deadline -and -not `$proc.HasExited){
+            try{
+                # Sample both counters in a single Get-Counter call: utilization (% Processor Time)
+                # AND achieved frequency (% Processor Performance, >100 means turbo, <100 means
+                # CPU is below nominal — the silicon-throttle fingerprint).
+                `$cs=(Get-Counter '\Processor(_Total)\% Processor Time','\Processor Information(_Total)\% Processor Performance' -ErrorAction Stop).CounterSamples
+                `$cpuSamples.Add([math]::Round(`$cs[0].CookedValue,1))
+                `$perfSamples.Add([math]::Round(`$cs[1].CookedValue,1))
+            }catch{}
+            Start-Sleep -Seconds 4
+        }
+    }
+    `$p95RanFull=-not `$proc.HasExited
+    Stop-Process -Id `$proc.Id -Force -ErrorAction SilentlyContinue
+    Get-Process -Name prime95 -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    `$t1=Get-Date
+
+    `$sec=[math]::Round((`$t1-`$t0).TotalSeconds,2)
+    `$res=if(Test-Path `$rf){(Get-Content `$rf -Raw -ErrorAction SilentlyContinue).Trim()}else{''}
+
+    `$evs=try{
+        Get-WinEvent -FilterHashtable @{
+            LogName='System';ProviderName='Microsoft-Windows-Kernel-Processor-Power'
+            StartTime=`$t0;EndTime=`$t1
+        } -ErrorAction Stop|Where-Object{`$_.Id -in 37,55}
+    }catch{@()}
+    `$e37=@(`$evs|Where-Object{`$_.Id -eq 37})
+    `$e55=@(`$evs|Where-Object{`$_.Id -eq 55})
+
+    `$byp=`$e37|
+        Group-Object{([regex]::Match(`$_.Message,'(?i)processor\s+(\d+)')).Groups[1].Value}|
+        Sort-Object{[int]`$_.Name}|
+        ForEach-Object{[pscustomobject]@{Proc=`$_.Name;Count=`$_.Count}}
+    `$bpj=if(`$byp){`$byp|ConvertTo-Json -Compress}else{'[]'}
+
+    `$p55=foreach(`$x in `$e55){
+        `$m=`$x.Message
+        `$pc=([regex]::Match(`$m,'(?i)processor\s+(\d+)')).Groups[1].Value
+        `$mp=([regex]::Match(`$m,'Minimum performance percentage:\s+(\d+)')).Groups[1].Value
+        if(`$pc -and `$mp){[pscustomobject]@{Proc=[int]`$pc;MinPct=[int]`$mp}}
+    }
+    `$wst=if(`$p55){(`$p55|Measure-Object MinPct -Minimum).Minimum}else{`$null}
+    `$avg=if(`$p55){[math]::Round((`$p55|Measure-Object MinPct -Average).Average,1)}else{`$null}
+
+    `$cn=(Get-WmiObject Win32_Processor|Select-Object -First 1).Name
+
+    [pscustomobject]@{
+        Status       = 'ok'
+        Hostname     = `$env:COMPUTERNAME
+        Timestamp    = `$t0.ToString('s')
+        CPU          = `$cn
+        Cores        = `$nc
+        DurSec       = `$dur
+        ActSec       = `$sec
+        CPU_MinPct   = if(`$cpuSamples.Count -gt 0){[math]::Round((`$cpuSamples|Measure-Object -Minimum).Minimum,1)}else{`$null}
+        CPU_MaxPct   = if(`$cpuSamples.Count -gt 0){[math]::Round((`$cpuSamples|Measure-Object -Maximum).Maximum,1)}else{`$null}
+        CPU_AvgPct   = if(`$cpuSamples.Count -gt 0){[math]::Round((`$cpuSamples|Measure-Object -Average).Average,1)}else{`$null}
+        CPU_Samples  = `$cpuSamples -join ','
+        Perf_MinPct  = if(`$perfSamples.Count -gt 0){[math]::Round((`$perfSamples|Measure-Object -Minimum).Minimum,1)}else{`$null}
+        Perf_MaxPct  = if(`$perfSamples.Count -gt 0){[math]::Round((`$perfSamples|Measure-Object -Maximum).Maximum,1)}else{`$null}
+        Perf_AvgPct  = if(`$perfSamples.Count -gt 0){[math]::Round((`$perfSamples|Measure-Object -Average).Average,1)}else{`$null}
+        Perf_Samples = `$perfSamples -join ','
+        P95_Started  = `$p95Started
+        P95_RanFull  = `$p95RanFull
+        P95_Results  = `$res
+        Ev37         = `$e37.Count
+        Ev37_ByProc  = `$bpj
+        Ev55         = `$e55.Count
+        Ev55_Worst   = `$wst
+        Ev55_Avg     = `$avg
+    }|ConvertTo-Json -Depth 5 -Compress
+}
+"@
+
+# ------------------ Stress-Node ------------------
+function Stress-Node {
+    param([Parameter(Mandatory)][string]$Fqdn)
+
+    if ($dry_run) {
+        Write-Host "[$Fqdn] DRY RUN: would stress for ${duration_secs}s."
+        return $null
+    }
+
+    Write-Host "[$Fqdn] Connecting..."
+    $res = Invoke-SSHPS -NodeName $Fqdn -PsCommand $stressPayload
+    $out = ($res.Output | Out-String).Trim()
+
+    if ($res.ExitCode -eq 255) {
+        Write-Host "[$Fqdn] SSH connection failed."
+        if ($script:failed_ssh -notcontains $Fqdn) { $script:failed_ssh += $Fqdn }
+        return $null
+    }
+    if ($res.ExitCode -ne 0) {
+        Write-Host "[$Fqdn] Remote execution failed (exit $($res.ExitCode))."
+        if ($script:failed_ssh -notcontains $Fqdn) { $script:failed_ssh += $Fqdn }
+        return $null
+    }
+
+    try { $obj = $out | ConvertFrom-Json }
+    catch {
+        Write-Host "[$Fqdn] No JSON in output. Remote said:`n$out"
+        if ($script:failed_ssh -notcontains $Fqdn) { $script:failed_ssh += $Fqdn }
+        return $null
+    }
+
+    if ($obj.Status -eq 'busy') {
+        Write-Host "[$Fqdn] Busy (task running). Will retry in ${retry_sleep_secs}s."
+        return "busy"
+    }
+
+    if ($pool -and $pool_name) { $obj | Add-Member -NotePropertyName Pool -NotePropertyValue $pool_name -Force }
+
+    Write-Host ("[$Fqdn] Done  Ev37={0}  CPU_Avg={1}%  Perf_Min={2}%  Perf_Avg={3}%  Perf_Max={4}%  Ev55_Worst={5}%  P95_Started={6}  P95_RanFull={7}  ActSec={8}" -f
+        $obj.Ev37, $obj.CPU_AvgPct, $obj.Perf_MinPct, $obj.Perf_AvgPct, $obj.Perf_MaxPct, $obj.Ev55_Worst, $obj.P95_Started, $obj.P95_RanFull, $obj.ActSec)
+    if ($obj.P95_Results) { Write-Host "[$Fqdn] P95: $($obj.P95_Results)" }
+
+    return $obj
+}
+
+# ------------------ Parallel runner ------------------
+function Invoke-Parallel {
+    param([string[]]$Fqdns, [switch]$IsRetry)
+
+    $rsPool   = [RunspaceFactory]::CreateRunspacePool(1, [math]::Max(1, $max_parallel))
+    $rsPool.Open()
+    $msgQueue = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
+
+    $rsScript = {
+        param(
+            [string]$Fqdn,
+            [string]$StressPayload,
+            [int]$DurationSecs,
+            [bool]$DryRun,
+            [bool]$PoolMode,
+            [string]$PoolName,
+            [string]$SshUser,
+            [System.Collections.Concurrent.ConcurrentQueue[string]]$MsgQueue
+        )
+
+        function Log { param([string]$Msg) $MsgQueue.Enqueue($Msg) }
+
+        function Invoke-SSH {
+            param([string]$NodeName,[string]$Command,[int]$TimeoutSec=300)
+            $target = if ($NodeName -match '@') { $NodeName } else { "$SshUser@$NodeName" }
+            $psi = [System.Diagnostics.ProcessStartInfo]::new('ssh')
+            $psi.Arguments              = "-o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no $target $Command"
+            $psi.UseShellExecute        = $false
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError  = $true
+            $psi.CreateNoWindow         = $true
+            $p       = [System.Diagnostics.Process]::Start($psi)
+            $outTask = $p.StandardOutput.ReadToEndAsync()
+            $errTask = $p.StandardError.ReadToEndAsync()
+            $exited  = $p.WaitForExit($TimeoutSec * 1000)
+            if (-not $exited) { try { $p.Kill() } catch {} }
+            $null = $outTask.Wait(10000)
+            $null = $errTask.Wait(10000)
+            $stdout   = if ($outTask.Status -eq 'RanToCompletion') { $outTask.Result } else { '' }
+            $exitCode = if ($exited) { $p.ExitCode } else { 255 }
+            $p.Dispose()
+            [pscustomobject]@{ Output=$stdout; ExitCode=$exitCode }
+        }
+        function Encode-PSCommand {
+            param([string]$Command)
+            $pref='$ProgressPreference=''SilentlyContinue'';$VerbosePreference=''SilentlyContinue'';$InformationPreference=''SilentlyContinue'';$WarningPreference=''SilentlyContinue'';'
+            $bytes=[System.Text.Encoding]::Unicode.GetBytes("$pref $Command")
+            [Convert]::ToBase64String($bytes)
+        }
+        function Invoke-SSHPS {
+            param([string]$NodeName,[string]$PsCommand)
+            Invoke-SSH -NodeName $NodeName -TimeoutSec ($DurationSecs + 90) -Command ("powershell -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -EncodedCommand $(Encode-PSCommand -Command $PsCommand)")
+        }
+
+        if ($DryRun) { Log "[$Fqdn] DRY RUN"; return [pscustomobject]@{_s='dry';Fqdn=$Fqdn} }
+
+        Log "[$Fqdn] Connecting..."
+        $res = Invoke-SSHPS -NodeName $Fqdn -PsCommand $StressPayload
+        $out = ($res.Output | Out-String).Trim()
+
+        if ($res.ExitCode -eq 255) { Log "[$Fqdn] SSH connection failed.";                  return [pscustomobject]@{_s='err';Fqdn=$Fqdn} }
+        if ($res.ExitCode -ne 0)   { Log "[$Fqdn] Remote failed (exit $($res.ExitCode)).";  return [pscustomobject]@{_s='err';Fqdn=$Fqdn} }
+
+        try   { $obj = $out | ConvertFrom-Json }
+        catch { Log "[$Fqdn] No JSON in output.`n$out";                                      return [pscustomobject]@{_s='err';Fqdn=$Fqdn} }
+
+        if ($obj.Status -eq 'busy') { Log "[$Fqdn] Busy (task running)."; return [pscustomobject]@{_s='busy';Fqdn=$Fqdn} }
+
+        if ($PoolMode -and $PoolName) { $obj | Add-Member -NotePropertyName Pool -NotePropertyValue $PoolName -Force }
+
+        Log ("[$Fqdn] Done  Ev37={0}  CPU_Avg={1}%  Perf_Min={2}%  Perf_Avg={3}%  Perf_Max={4}%  Ev55_Worst={5}%  P95_Started={6}  P95_RanFull={7}  ActSec={8}" -f
+            $obj.Ev37,$obj.CPU_AvgPct,$obj.Perf_MinPct,$obj.Perf_AvgPct,$obj.Perf_MaxPct,$obj.Ev55_Worst,$obj.P95_Started,$obj.P95_RanFull,$obj.ActSec)
+        if ($obj.P95_Results) { Log "[$Fqdn] P95: $($obj.P95_Results)" }
+        return $obj
+    }
+
+    function Drain-Queue {
+        $msg = $null
+        while ($msgQueue.TryDequeue([ref]$msg)) { Write-Host $msg; $msg = $null }
+    }
+
+    # Process in discrete batches — all nodes in a batch run concurrently,
+    # and the next batch does not start until every node in the current batch completes.
+    $totalBatches = [math]::Ceiling($Fqdns.Count / $max_parallel)
+    $batchNum     = 0
+
+    for ($i = 0; $i -lt $Fqdns.Count; $i += $max_parallel) {
+        $batchNum++
+        $batch = $Fqdns[$i..[math]::Min($i + $max_parallel - 1, $Fqdns.Count - 1)]
+
+        Write-Host ""
+        Write-Host ("  -- Batch {0}/{1}  ({2} node(s)) --" -f $batchNum, $totalBatches, $batch.Count)
+
+        $jobs = [System.Collections.Generic.List[object]]::new()
+        foreach ($fqdn in $batch) {
+            $ps = [PowerShell]::Create()
+            $ps.RunspacePool = $rsPool
+            [void]$ps.AddScript($rsScript)
+            [void]$ps.AddParameters(@{
+                Fqdn          = $fqdn
+                StressPayload = $stressPayload
+                DurationSecs  = $duration_secs
+                DryRun        = [bool]$dry_run
+                PoolMode      = [bool]$pool
+                PoolName      = $pool_name
+                SshUser       = $ssh_user
+                MsgQueue      = $msgQueue
+            })
+            $jobs.Add([pscustomobject]@{ PS=$ps; Handle=$ps.BeginInvoke(); Fqdn=$fqdn })
+        }
+
+        # Wait for every job in this batch before starting the next
+        $pending       = [System.Collections.Generic.List[object]]::new($jobs)
+        $lastHeartbeat = [datetime]::Now
+        while ($pending.Count -gt 0) {
+            Drain-Queue
+            if (([datetime]::Now - $lastHeartbeat).TotalSeconds -ge 30) {
+                Write-Host ("  [waiting] Batch {0}/{1}: {2} node(s) still running..." -f $batchNum, $totalBatches, $pending.Count)
+                $lastHeartbeat = [datetime]::Now
+            }
+            $done = @($pending | Where-Object { $_.Handle.IsCompleted })
+            foreach ($job in $done) {
+                [void]$pending.Remove($job)
+                try   { $r = $job.PS.EndInvoke($job.Handle)[0] }
+                catch { $msgQueue.Enqueue("[$($job.Fqdn)] Runspace error: $_"); $r = [pscustomobject]@{_s='err';Fqdn=$job.Fqdn} }
+                $job.PS.Dispose()
+
+                $rs = if ($r -and $r.PSObject.Properties['_s']) { $r._s } else { $null }
+                if     ($null -eq $r -or $rs -eq 'dry')  { }
+                elseif ($rs -eq 'err')                    { if ($script:failed_ssh -notcontains $job.Fqdn) { $script:failed_ssh  += $job.Fqdn } }
+                elseif ($rs -eq 'busy')                   { if ($script:busy_nodes -notcontains $job.Fqdn) { $script:busy_nodes  += $job.Fqdn } }
+                else {
+                    $script:results += $r
+                    if ($IsRetry -and $script:retry_recovered -notcontains $job.Fqdn) { $script:retry_recovered += $job.Fqdn }
+                }
+            }
+            if ($pending.Count -gt 0) { Start-Sleep -Milliseconds 250 }
+        }
+        Drain-Queue
+    }
+
+    $rsPool.Close()
+    $rsPool.Dispose()
+}
+
+# ------------------ PASS 1 ------------------
+Write-Host ""
+Write-Host "------------------------------------------------------------"
+Write-Host "         PASS 1 (STRESS + MEASURE THROTTLING)              "
+Write-Host ("   Duration: {0}s   Nodes: {1}   Parallel: {2}   Dry run: {3}" -f $duration_secs, $targets.Count, $(if ($parallel) { "$max_parallel per batch" } else { "off" }), $dry_run)
+Write-Host "------------------------------------------------------------"
+Write-Host ""
+
+if ($parallel) {
+    Invoke-Parallel -Fqdns $targets
+} else {
+    foreach ($fqdn in $targets) {
+        $result = Stress-Node -Fqdn $fqdn
+        if     ($result -is [string] -and $result -eq 'busy') { if ($script:busy_nodes -notcontains $fqdn) { $script:busy_nodes += $fqdn } }
+        elseif ($result)                                       { $script:results += $result }
+    }
+}
+
+# ------------------ Busy retry loop ------------------
+$busyPass = 0
+while (-not $no_retry -and $script:busy_nodes.Count -gt 0) {
+    $busyPass++
+    $pending           = @($script:busy_nodes | Sort-Object -Unique)
+    $script:busy_nodes = @()
+
+    Sleep-BetweenPasses -Seconds $retry_sleep_secs -Label "busy retry $busyPass - $($pending.Count) node(s) running a task"
+    Write-Host "---- BUSY RETRY $busyPass ($($pending.Count) node(s)) ----"
+    Write-Host ""
+
+    if ($parallel) {
+        Invoke-Parallel -Fqdns $pending
+    } else {
+        foreach ($fqdn in $pending) {
+            $result = Stress-Node -Fqdn $fqdn
+            if     ($result -is [string] -and $result -eq 'busy') { $script:busy_nodes += $fqdn }
+            elseif ($result)                                       { $script:results += $result }
+        }
+    }
+}
+
+# ------------------ SSH retry loop ------------------
+$sshPass = 0
+while (-not $no_retry -and $script:failed_ssh.Count -gt 0 -and $sshPass -lt $ssh_max_retries) {
+    $sshPass++
+    $retry             = @($script:failed_ssh | Sort-Object -Unique)
+    $script:failed_ssh = @()
+
+    Sleep-BetweenPasses -Seconds $retry_sleep_secs -Label "SSH retry $sshPass of $ssh_max_retries - $($retry.Count) node(s)"
+    Write-Host "---- SSH RETRY $sshPass of $ssh_max_retries ($($retry.Count) node(s)) ----"
+    Write-Host ""
+
+    if ($parallel) {
+        Invoke-Parallel -Fqdns $retry -IsRetry
+    } else {
+        foreach ($fqdn in $retry) {
+            $result = Stress-Node -Fqdn $fqdn
+            if     ($result -is [string] -and $result -eq 'busy') { if ($script:busy_nodes -notcontains $fqdn) { $script:busy_nodes += $fqdn } }
+            elseif ($result) {
+                $script:results += $result
+                if ($script:retry_recovered -notcontains $fqdn) { $script:retry_recovered += $fqdn }
+            }
+        }
+    }
+
+    # Drain any busy nodes that surfaced during this SSH retry round
+    while ($script:busy_nodes.Count -gt 0) {
+        $busyPass++
+        $pending           = @($script:busy_nodes | Sort-Object -Unique)
+        $script:busy_nodes = @()
+        Sleep-BetweenPasses -Seconds $retry_sleep_secs -Label "busy retry $busyPass (during SSH retry) - $($pending.Count) node(s)"
+        foreach ($fqdn in $pending) {
+            $result = Stress-Node -Fqdn $fqdn
+            if     ($result -is [string] -and $result -eq 'busy') { $script:busy_nodes += $fqdn }
+            elseif ($result) {
+                $script:results += $result
+                if ($script:retry_recovered -notcontains $fqdn) { $script:retry_recovered += $fqdn }
+            }
+        }
+    }
+}
+
+# ------------------ CSV output ------------------
+if ([string]::IsNullOrWhiteSpace($output_name)) {
+    $output_name = "cpu_stress_{0}_{1}.csv" -f $script:tag, $script:stamp
+}
+$outCsv = Join-Path $output_dir $output_name
+
+if ($dry_run) {
+    Write-Host "DRY RUN: would write CSV to $outCsv"
+} else {
+    $okHosts = @($script:results | ForEach-Object { $_.Hostname }) | Sort-Object -Unique
+    foreach ($fqdn in @($targets | Sort-Object -Unique)) {
+        $short = $fqdn -replace ("\." + [regex]::Escape($domain_suffix) + "$"), ""
+        if ($okHosts -notcontains $short -and $okHosts -notcontains $fqdn) {
+            $script:results += [pscustomobject]@{
+                Hostname  = $short
+                Timestamp = (Get-Date).ToString("s")
+                Error     = "No result after $ssh_max_retries SSH retries"
+            }
+        }
+    }
+    $script:results | Export-Csv -Path $outCsv -NoTypeInformation -Encoding UTF8
+    Write-Host "CSV : $outCsv"
+}
+
+# ------------------ Summary ------------------
+Write-Host ""
+Write-Host "==== SUMMARY ===="
+Write-Host ("Duration per node : {0}s" -f $duration_secs)
+Write-Host ("Nodes targeted    : {0}"  -f $targets.Count)
+Write-Host ""
+
+$good = @($script:results | Where-Object { -not $_.PSObject.Properties['Error'] })
+if ($good.Count -gt 0) {
+    $good |
+        Select-Object Hostname, ActSec, CPU_AvgPct, Perf_MinPct, Perf_AvgPct, Perf_MaxPct, Ev37, Ev55_Worst, Ev55_Avg, P95_Started, P95_RanFull |
+        Sort-Object Ev37 -Descending |
+        Format-Table -AutoSize |
+        Out-String |
+        Write-Host
+}
+
+Write-Host "Failed (after all retries):"
+if (@($script:failed_ssh).Count -gt 0) { $script:failed_ssh | Sort-Object -Unique | ForEach-Object { Write-Host "  - $_" } }
+else { Write-Host "  none" }
+
+Write-Host ""
+Write-Host "Recovered on retry:"
+if (@($script:retry_recovered).Count -gt 0) { $script:retry_recovered | Sort-Object -Unique | ForEach-Object { Write-Host "  - $_" } }
+else { Write-Host "  none" }
+
+Write-Host ""
+Write-Host "Log : $logFile"
+Write-Host "CSV : $outCsv"
+
+Stop-Transcript

--- a/provisioners/windows/MDC1Windows/utility_scripts/stress_test/StressSP3-Fleet.ps1
+++ b/provisioners/windows/MDC1Windows/utility_scripts/stress_test/StressSP3-Fleet.ps1
@@ -1,0 +1,150 @@
+# StressSP3-Fleet.ps1
+# Fleet-wide SP3 stress test wrapper around StressSP3.ps1.
+#
+# What this is for: run the validated Speedometer 3 + Marionette + ETW workload
+# from StressSP3.ps1 against every NUC13 in the fleet (default range 1..160),
+# with the same retry / busy-skip / skip-list semantics StressCPU.ps1 uses for
+# the prime95 fleet sweeps. Used in RELOPS-2323 to score every node under a
+# realistic CI workload after the 2026-05-07 Perf_Max scan identified the
+# suspected service candidates.
+#
+# Behavior:
+#   - Builds a node list by expanding nuc13-NNN across [-range_start..-range_end]
+#     OR explicit -nodes "a,b,c" OR -single -node nuc13-XXX.
+#   - Filters out known-bad PSU / deployment-failure nodes (same skip list as
+#     StressCPU.ps1) unless -no_skip is passed.
+#   - Forwards every SP3-specific switch (loops, iterations, duration, etc.)
+#     verbatim to StressSP3.ps1 along with the expanded node list.
+#   - StressSP3.ps1 already implements: 3-pass SSH retry, busy-skip with retry
+#     pass, parallel execution per max_parallel, busy detection via
+#     worker-status.json, scp+ssh-File transport as Administrator. We rely on
+#     all of that and just feed it a fleet-scale node list.
+#
+# Usage:
+#   .\StressSP3-Fleet.ps1                                    # default 1..160 sweep, 1 SP3 loop, 600s cap
+#   .\StressSP3-Fleet.ps1 -sp3_loops 9 -duration_secs 600    # ~10-min CI-like run per node
+#   .\StressSP3-Fleet.ps1 -range_start 1 -range_end 50       # subset
+#   .\StressSP3-Fleet.ps1 -nodes "nuc13-077,nuc13-079"       # explicit list
+#   .\StressSP3-Fleet.ps1 -single -node nuc13-029            # one node
+#   .\StressSP3-Fleet.ps1 -dry_run                           # show targets, do not execute
+#   .\StressSP3-Fleet.ps1 -no_skip                           # disable the PSU-skip filter
+#
+# Output is whatever StressSP3.ps1 produces: CSV + transcript log in
+# $output_dir (default C:\logs).
+
+param(
+    # Range mode (default)
+    [int]$range_start      = 1,
+    [int]$range_end        = 160,
+    [int]$range_pad        = 3,
+    [string]$range_prefix  = "nuc13",
+
+    # Explicit overrides (bypass range)
+    [string]$nodes         = "",
+    [switch]$single,
+    [string]$node          = "",
+
+    # SSH / transport (forwarded)
+    [string]$ssh_user      = "Administrator",
+    [int]$ssh_max_retries  = 3,
+    [int]$retry_sleep_secs = 120,
+    [int]$max_parallel     = 3,
+
+    # SP3 workload (forwarded)
+    [int]$duration_secs    = 600,
+    [int]$sp3_loops        = 1,
+    [int]$sp3_iterations   = 10,
+    [switch]$visible,
+    [switch]$test_remote,
+    [switch]$quick,
+
+    # Skip list / dry-run / retry control
+    [switch]$no_skip,
+    [switch]$dry_run,
+    [switch]$no_retry,
+
+    [string]$output_dir    = "C:\logs"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ------------------ Skip list (matches StressCPU.ps1) ------------------
+$skip_nodes = @(
+    "nuc13-035","nuc13-036","nuc13-059","nuc13-060","nuc13-061",
+    "nuc13-068","nuc13-070","nuc13-075","nuc13-096","nuc13-112",
+    "nuc13-130","nuc13-149","nuc13-154","nuc13-155","nuc13-156","nuc13-157",
+    "nuc13-107","nuc13-150"
+)
+
+# ------------------ Resolve target node list ------------------
+$target_shorts = @()
+if ($single) {
+    if (-not $node) { Write-Error "-node is required with -single"; exit 1 }
+    $target_shorts = @(($node -replace '\..*$', '').Trim())
+}
+elseif ($nodes) {
+    $target_shorts = @($nodes -split '[,\s]+' | Where-Object { $_ } | ForEach-Object { ($_ -replace '\..*$', '').Trim() })
+}
+else {
+    # Range mode (default)
+    $target_shorts = $range_start..$range_end | ForEach-Object {
+        "{0}-{1:D$range_pad}" -f $range_prefix, $_
+    }
+}
+
+# Apply skip list
+if (-not $no_skip -and -not $single) {
+    $before = $target_shorts.Count
+    $hit = @($target_shorts | Where-Object { $skip_nodes -contains $_ })
+    $target_shorts = @($target_shorts | Where-Object { $skip_nodes -notcontains $_ })
+    if ($hit.Count -gt 0) {
+        Write-Host "Skipping $($hit.Count) known-problem node(s): $($hit -join ', ')" -ForegroundColor Yellow
+    }
+}
+
+if ($target_shorts.Count -eq 0) { Write-Error "No nodes to scan."; exit 1 }
+
+Write-Host ""
+Write-Host "------------------------------------------------------------"
+Write-Host "  StressSP3-Fleet wrapper"
+Write-Host "  Targets    : $($target_shorts.Count) node(s)"
+Write-Host "  Range      : $range_start..$range_end (skip list active: $(-not $no_skip))"
+Write-Host "  SP3 loops  : $sp3_loops"
+Write-Host "  Iterations : $sp3_iterations"
+Write-Host "  Per-node   : up to $duration_secs s"
+Write-Host "  Parallel   : $max_parallel"
+Write-Host "  Visible    : $visible"
+Write-Host "  Dry run    : $dry_run"
+Write-Host "------------------------------------------------------------"
+Write-Host ""
+
+# ------------------ Forward to StressSP3.ps1 ------------------
+$sp3Path = Join-Path $PSScriptRoot "StressSP3.ps1"
+if (-not (Test-Path $sp3Path)) {
+    Write-Error "StressSP3.ps1 not found at $sp3Path"
+    exit 1
+}
+
+# Build argument hashtable. StressSP3.ps1 takes -nodes as a string.
+$nodesArg = $target_shorts -join ","
+
+$invokeArgs = @{
+    nodes              = $nodesArg
+    ssh_user           = $ssh_user
+    ssh_max_retries    = $ssh_max_retries
+    retry_sleep_secs   = $retry_sleep_secs
+    max_parallel       = $max_parallel
+    duration_secs      = $duration_secs
+    sp3_loops          = $sp3_loops
+    sp3_iterations     = $sp3_iterations
+    output_dir         = $output_dir
+}
+if ($visible)     { $invokeArgs.visible     = $true }
+if ($test_remote) { $invokeArgs.test_remote = $true }
+if ($quick)       { $invokeArgs.quick       = $true }
+if ($dry_run)     { $invokeArgs.dry_run     = $true }
+if ($no_retry)    { $invokeArgs.no_retry    = $true }
+
+# Splat into the underlying script
+& $sp3Path @invokeArgs

--- a/provisioners/windows/MDC1Windows/utility_scripts/stress_test/StressSP3.ps1
+++ b/provisioners/windows/MDC1Windows/utility_scripts/stress_test/StressSP3.ps1
@@ -1,0 +1,1150 @@
+# StressSP3.ps1
+# SSH-driven Speedometer 3.1 replication harness for the wintest2 NUC13 fleet,
+# built for RELOPS-2323 throttling investigation 2026-05-07.
+#
+# Per node, the harness:
+#   - logs in as Administrator via scp+ssh -File transport (avoids the cmd.exe
+#     8191-char limit that silently truncates -EncodedCommand on this fleet)
+#   - detects the active interactive task user via `query user`
+#   - launches Firefox in the task user's session via a one-shot scheduled task
+#     with -LogonType Interactive (no password needed - uses the user's logon
+#     token), so the workload runs in the same context Mozilla CI uses
+#   - drives Speedometer 3.1 via Marionette over TCP 2828 (custom Python client)
+#   - loops the SP3 run -sp3_loops times in the same Firefox to approximate
+#     CI's ~10-min Browsertime cycle window
+#   - captures Microsoft-Windows-Kernel-Processor-Power ETW events Ev37/48/51/55/58
+#     and CPU sampling alongside the workload
+#   - returns per-loop scores plus throttling counters as JSON
+#
+# Modes:
+#   -single -node nuc13-XXX           one node
+#   -nodes "n1,n2,n3"                 explicit list (parallel by default)
+#   default                           20-node May 2026 perf-anomaly list
+#   -test_remote                      pipeline smoke test with a tiny payload
+#   -visible                          drop --headless so Firefox shows on the desktop
+#   -sp3_loops N                      number of SP3 cycles per node (default 1)
+#   -sp3_iterations N                 SP3 internal iteration count (default 10)
+#   -duration_secs N                  per-node safety cap on the sample loop
+#
+# Output: CSV + transcript log in C:\logs.
+
+param(
+    [int]$duration_secs    = 600,
+    [int]$retry_sleep_secs = 120,
+    [int]$ssh_max_retries  = 3,
+    [int]$max_parallel     = 3,
+    [string]$output_dir    = "C:\logs",
+    [switch]$quick,
+    [switch]$dry_run,
+    [switch]$no_retry,
+    [switch]$single,
+    [string]$node          = "",
+    [switch]$test_remote,
+    [string]$ssh_user      = "Administrator",
+    [switch]$visible,
+    [int]$sp3_iterations   = 10,
+    [int]$sp3_loops        = 1,
+    [string]$nodes         = ""
+)
+
+# -quick: 420s cap — enough to let one SP3 run actually finish (~5-7 min) so we can
+# validate the score-element detection and ETW capture end-to-end on a single node.
+# For pipeline-only smoke tests (no full SP3 run), use -test_remote instead.
+if ($quick) { $duration_secs = 420; $retry_sleep_secs = 10 }
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:stamp           = (Get-Date).ToString("yyyyMMdd_HHmmss")
+$script:failed_ssh      = @()
+$script:retry_recovered = @()
+$script:busy_nodes      = @()
+$script:results         = @()
+
+$domain_suffix    = "wintest2.releng.mdc1.mozilla.com"
+$ssh_timeout_secs = $duration_secs + 600   # choco install/uninstall + FF startup + SP3 run + ETW analysis
+
+$target_shorts = @(
+    "nuc13-029","nuc13-137","nuc13-028","nuc13-051","nuc13-025",
+    "nuc13-043","nuc13-143","nuc13-062","nuc13-138","nuc13-134",
+    "nuc13-039","nuc13-092","nuc13-076","nuc13-042","nuc13-140",
+    "nuc13-119","nuc13-116","nuc13-030","nuc13-074","nuc13-071"
+)
+if ($nodes) {
+    $target_shorts = @($nodes -split '[,\s]+' | Where-Object { $_ } | ForEach-Object { ($_ -replace '\..*$', '').Trim() })
+}
+if ($single) {
+    if (-not $node) { Write-Error "-node is required with -single"; exit 1 }
+    $target_shorts = @($node -replace '\..*$', '')
+}
+$targets = @($target_shorts | ForEach-Object { "$_.$domain_suffix" })
+
+# ------------------ Helpers ------------------
+function Ensure-Dir {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { New-Item -ItemType Directory -Path $Path -Force | Out-Null }
+}
+
+function Sleep-BetweenPasses {
+    param([int]$Seconds, [string]$Label = "")
+    Write-Host ""
+    Write-Host ("---- Sleeping {0}s{1} ----" -f $Seconds, $(if ($Label) { " : $Label" } else { "" }))
+    Start-Sleep -Seconds $Seconds
+    Write-Host ""
+}
+
+function Invoke-SSH {
+    param([Parameter(Mandatory)][string]$NodeName, [Parameter(Mandatory)][string]$Command,
+          [int]$TimeoutSec = 600, [string]$StdinText = "")
+    $target = if ($NodeName -match '@') { $NodeName } else { "$ssh_user@$NodeName" }
+    $psi = [System.Diagnostics.ProcessStartInfo]::new('ssh')
+    $psi.Arguments              = "-o ConnectTimeout=15 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no $target $Command"
+    $psi.UseShellExecute        = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.RedirectStandardInput  = $true
+    $psi.CreateNoWindow         = $true
+    $p = [System.Diagnostics.Process]::Start($psi)
+    $outTask = $p.StandardOutput.ReadToEndAsync()
+    $errTask = $p.StandardError.ReadToEndAsync()
+    if ($StdinText) { $p.StandardInput.Write($StdinText) }
+    $p.StandardInput.Close()
+    $exited  = $p.WaitForExit($TimeoutSec * 1000)
+    if (-not $exited) { try { $p.Kill() } catch {} }
+    $null = $outTask.Wait(10000)
+    $null = $errTask.Wait(10000)
+    $stdout   = if ($outTask.Status -eq 'RanToCompletion') { $outTask.Result } else { '' }
+    $stderr   = if ($errTask.Status -eq 'RanToCompletion') { $errTask.Result } else { '' }
+    $exitCode = if ($exited) { $p.ExitCode } else { 255 }
+    $p.Dispose()
+    [pscustomobject]@{ Output = $stdout; Error = $stderr; ExitCode = $exitCode }
+}
+
+function Invoke-SSHPS {
+    param([Parameter(Mandatory)][string]$NodeName, [Parameter(Mandatory)][string]$PsCommand)
+    # Upload payload via scp to the remote home dir, then run with `powershell -File`.
+    # Why: -EncodedCommand routes through cmd.exe on the Windows OpenSSH server, which
+    # has an 8191-char command-line limit. Our payload exceeds that and was being silently
+    # truncated, producing exit 0 with empty stdout. scp + -File sidesteps it entirely.
+    $remoteName = "stress_payload_$([guid]::NewGuid().ToString('N')).ps1"
+    $localTemp  = Join-Path $env:TEMP $remoteName
+    Set-Content -Path $localTemp -Value $PsCommand -Encoding UTF8
+
+    $scpTarget = if ($NodeName -match '@') { $NodeName } else { "$ssh_user@$NodeName" }
+    Write-Host ("[$NodeName] payload={0}B  remote={1}  user={2}" -f $PsCommand.Length, $remoteName, $ssh_user)
+
+    try {
+        $scpArgs = "-O -o ConnectTimeout=15 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no `"$localTemp`" `"${scpTarget}:$remoteName`""
+        $psi = [System.Diagnostics.ProcessStartInfo]::new('scp')
+        $psi.Arguments              = $scpArgs
+        $psi.UseShellExecute        = $false
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError  = $true
+        $psi.CreateNoWindow         = $true
+        $sp = [System.Diagnostics.Process]::Start($psi)
+        $scpOut = $sp.StandardOutput.ReadToEnd()
+        $scpErr = $sp.StandardError.ReadToEnd()
+        $null = $sp.WaitForExit(60000)
+        $scpExit = $sp.ExitCode
+        $sp.Dispose()
+        if ($scpExit -ne 0) {
+            return [pscustomobject]@{ Output = ''; Error = "scp failed (exit $scpExit): $scpOut $scpErr"; ExitCode = 254 }
+        }
+
+        # Run via -File using cmd.exe %USERPROFILE% expansion; self-delete after.
+        $remoteCmd = "powershell -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File `"`$env:USERPROFILE\$remoteName`"; Remove-Item `"`$env:USERPROFILE\$remoteName`" -Force -ErrorAction SilentlyContinue"
+        Invoke-SSH -NodeName $NodeName -TimeoutSec $ssh_timeout_secs -Command $remoteCmd
+    } finally {
+        Remove-Item $localTemp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ------------------ Start transcript ------------------
+Ensure-Dir -Path $output_dir
+$logFile = Join-Path $output_dir ("stress_sp3_list-{0}nodes_{1}.log" -f $targets.Count, $script:stamp)
+Start-Transcript -Path $logFile -Append
+Write-Host "Log : $logFile"
+Write-Host ""
+
+# ------------------ Remote payload ------------------
+# $duration_secs is baked in at construction time (no backtick).
+# All remote variables use backtick-escaped $.
+$stressPayload = @"
+`$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# --- Busy check ---
+`$wsp = `$null
+foreach (`$p in @("C:\WINDOWS\SystemTemp", `$env:TMP, `$env:TEMP, `$env:USERPROFILE)) {
+    if (`$p) { `$c = Join-Path `$p "worker-status.json"; if (Test-Path `$c) { `$wsp = `$c; break } }
+}
+`$busy = `$false
+if (`$wsp) {
+    try { `$j = Get-Content `$wsp -Raw | ConvertFrom-Json; if (@(`$j.currentTaskIds).Count -gt 0) { `$busy = `$true } } catch {}
+}
+if (`$busy) {
+    [pscustomobject]@{ Status = 'busy'; Hostname = `$env:COMPUTERNAME } | ConvertTo-Json -Compress
+    return
+}
+
+# --- Pre-clean leftover state from any abandoned prior StressSP3 run ---
+# Only reached when busy=false, so we won't disturb a real CI task. Self-heals
+# the node so a previous run's hung Firefox / scheduled task / xperf session
+# doesn't break this one.
+try { Get-Process firefox -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
+try { `$null = & xperf -stop 2>`$null } catch {}
+try {
+    `$leftoverLogman = & logman query -ets 2>`$null | Select-String 'StressProcPower_'
+    foreach (`$row in `$leftoverLogman) {
+        `$lname = (`$row.Line -split '\s+')[0]
+        if (`$lname) { try { `$null = & logman stop `$lname -ets 2>`$null } catch {} }
+    }
+} catch {}
+try { Get-ScheduledTask -TaskName 'StressSP3_FF_*' -ErrorAction SilentlyContinue | Unregister-ScheduledTask -Confirm:`$false -ErrorAction SilentlyContinue } catch {}
+try { Remove-Item 'C:\Users\Public\sp3stress' -Recurse -Force -ErrorAction SilentlyContinue } catch {}
+
+# --- Paths / timestamps ---
+`$ts      = (Get-Date).ToString('yyyyMMddHHmmss')
+`$dur     = $duration_secs
+`$workDir = 'C:\Users\Public\sp3stress'
+`$logDir  = 'C:\logs'
+if (-not (Test-Path `$workDir)) { New-Item -ItemType Directory `$workDir -Force | Out-Null }
+if (-not (Test-Path `$logDir))  { New-Item -ItemType Directory `$logDir  -Force | Out-Null }
+`$kernelEtl   = Join-Path `$logDir "stress_kernel_`$ts.etl"
+`$userEtl     = Join-Path `$logDir "stress_procpower_`$ts.etl"
+`$sessionName = "StressProcPower_`$ts"
+`$pyFile      = Join-Path `$workDir "marionette_`$ts.py"
+`$pyOutFile   = Join-Path `$workDir "marionette_out_`$ts.txt"
+`$pyErrFile   = Join-Path `$workDir "marionette_err_`$ts.txt"
+`$ffProfile   = Join-Path `$workDir "ff_profile_`$ts"
+`$ffSchedTask = "StressSP3_FF_`$ts"
+
+# --- Locate xperf ---
+`$xperfExe = @(
+    'C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\xperf.exe',
+    'C:\Program Files\Windows Kits\10\Windows Performance Toolkit\xperf.exe'
+) | Where-Object { Test-Path `$_ } | Select-Object -First 1
+`$xperfOK = `$null -ne `$xperfExe
+
+# --- Firefox: check if already installed; only install (and uninstall) if not ---
+`$ffPaths = @(
+    'C:\Program Files\Mozilla Firefox\firefox.exe',
+    'C:\Program Files (x86)\Mozilla Firefox\firefox.exe'
+)
+`$ffExe           = `$ffPaths | Where-Object { Test-Path `$_ } | Select-Object -First 1
+`$ffAlreadyHere   = `$null -ne `$ffExe
+`$chocoInstall    = `$false
+`$chocoOutput     = ''
+if (-not `$ffExe) {
+    try   { `$chocoOutput = (& choco install firefox --yes --no-progress --limit-output --force 2>&1) -join "`n" }
+    catch { `$chocoOutput = `$_.Exception.Message }
+    `$chocoInstall = (`$LASTEXITCODE -eq 0)
+    `$ffExe        = `$ffPaths | Where-Object { Test-Path `$_ } | Select-Object -First 1
+}
+`$ffOK = `$null -ne `$ffExe
+
+# --- Python path ---
+`$pythonCandidates = @(
+    'C:\mozilla-build\python3\python3.exe',
+    'C:\mozilla-build\python\python.exe',
+    'C:\Python313\python.exe',
+    'C:\Python312\python.exe',
+    'C:\Python311\python.exe',
+    'C:\Python310\python.exe'
+)
+`$pythonExe = `$pythonCandidates | Where-Object { Test-Path `$_ } | Select-Object -First 1
+if (-not `$pythonExe) {
+    foreach (`$cmd in 'python3','python','py') {
+        try {
+            `$found = & where.exe `$cmd 2>`$null
+            if (`$found) { `$pythonExe = (`$found | Select-Object -First 1).Trim(); break }
+        } catch {}
+    }
+}
+`$pythonFound = (`$null -ne `$pythonExe -and (Test-Path `$pythonExe))
+
+# --- Write Marionette Python script ---
+# Navigates to SP3, starts it, then polls benchmarkClient._isRunning until the
+# full benchmark completes. Exits only when SP3 is done (or max_polls exceeded).
+`$pyContent = @'
+import socket, json, time, sys
+
+def recv_msg(s):
+    buf = b''
+    while b':' not in buf:
+        c = s.recv(256)
+        if not c:
+            raise IOError('connection closed before delimiter')
+        buf += c
+    colon = buf.index(b':')
+    n = int(buf[:colon])
+    data = buf[colon+1:]
+    while len(data) < n:
+        data += s.recv(4096)
+    return json.loads(data[:n].decode('utf-8'))
+
+_mid = [0]
+def send_cmd(s, cmd, params):
+    _mid[0] += 1
+    msg = json.dumps([0, _mid[0], cmd, params])
+    s.sendall((str(len(msg)) + ':' + msg).encode('utf-8'))
+    return recv_msg(s)
+
+def script_value(r):
+    # Marionette wraps WebDriver:ExecuteScript results in {"value": ...}
+    v = r[3]
+    if isinstance(v, dict) and 'value' in v:
+        return v['value']
+    return v
+
+sock = None
+for attempt in range(40):
+    try:
+        sock = socket.create_connection(('127.0.0.1', 2828), timeout=5)
+        break
+    except Exception as ex:
+        if attempt == 39:
+            print('MARIONETTE_CONNECT_FAILED:' + str(ex))
+            sys.exit(1)
+        time.sleep(1)
+
+try:
+    sock.settimeout(3)
+    try:
+        greeting = recv_msg(sock)
+        print('GREETING:' + json.dumps(greeting))
+    except socket.timeout:
+        print('NO_GREETING')
+    sock.settimeout(60)
+
+    r = send_cmd(sock, 'WebDriver:NewSession', {'capabilities': {}})
+    if r[2]:
+        print('SESSION_ERROR:' + json.dumps(r[2]))
+        sys.exit(1)
+    sid = r[3].get('sessionId', 'none') if r[3] else 'none'
+    print('SESSION:' + sid)
+
+    # Run SP3 in a loop to match the wall-clock duration of CI Raptor/Browsertime
+    # cycles (which restart Firefox per cycle ~25 times). We keep one Firefox
+    # instance and re-navigate to the SP3 URL per loop, which approximates the
+    # sustained CPU load CI puts on the worker over ~10 minutes total.
+    SP3_LOOPS      = __SP3_LOOPS__
+    SP3_ITERATIONS = __SP3_ITERATIONS__
+    all_scores     = []
+    fail_reason    = None
+    max_polls      = 150  # 150 * 5s = 12.5 min per individual SP3 loop
+
+    for loop_n in range(SP3_LOOPS):
+        print('SP3_LOOP_BEGIN:' + str(loop_n + 1) + '/' + str(SP3_LOOPS))
+
+        r = send_cmd(sock, 'WebDriver:Navigate', {'url': 'https://browserbench.org/Speedometer3.1/'})
+        print('NAVIGATE_' + str(loop_n) + ':' + str(r[2]))
+
+        page_ready = False
+        for wait_n in range(30):
+            r = send_cmd(sock, 'WebDriver:ExecuteScript', {
+                'script': 'return document.readyState === "complete" ? "ready" : "not_ready";',
+                'args': []
+            })
+            if str(script_value(r)) == 'ready':
+                print('PAGE_READY_' + str(loop_n) + ':' + str(wait_n) + 's')
+                page_ready = True
+                break
+            time.sleep(1)
+        if not page_ready:
+            print('PAGE_READY_TIMEOUT_' + str(loop_n))
+            try:
+                r = send_cmd(sock, 'WebDriver:ExecuteScript', {
+                    'script': (
+                        'try { return JSON.stringify({'
+                        '  url: document.location ? document.location.href : null,'
+                        '  title: document.title,'
+                        '  state: document.readyState,'
+                        '  body: document.body ? (document.body.innerText || "").substring(0, 400) : null'
+                        '}); } catch(e) { return "ERR:" + e.message; }'
+                    ),
+                    'args': []
+                })
+                print('PAGE_DIAG_' + str(loop_n) + ':' + str(script_value(r)))
+            except Exception as ex:
+                print('PAGE_DIAG_ERROR_' + str(loop_n) + ':' + str(ex))
+            fail_reason = 'page_load_timeout'
+            break
+
+        r = send_cmd(sock, 'WebDriver:ExecuteScript', {
+            'script': (
+                'try {'
+                '  var n = ' + str(SP3_ITERATIONS) + ';'
+                '  if (typeof benchmarkClient !== "undefined") {'
+                '    try { benchmarkClient._iterationCount = n; } catch(_) {}'
+                '    try { benchmarkClient.iterationCount  = n; } catch(_) {}'
+                '    if (benchmarkClient._runner) {'
+                '      try { benchmarkClient._runner._iterationCount = n; } catch(_) {}'
+                '      try { benchmarkClient._runner.iterationCount  = n; } catch(_) {}'
+                '    }'
+                '  }'
+                '  benchmarkClient.start(n);'
+                '  var actual = (benchmarkClient && (benchmarkClient._iterationCount || benchmarkClient.iterationCount)) ||'
+                '               (benchmarkClient && benchmarkClient._runner && (benchmarkClient._runner._iterationCount || benchmarkClient._runner.iterationCount)) ||'
+                '               "unknown";'
+                '  return "STARTED_API:requested=" + n + ",configured=" + actual;'
+                '} catch(e1) {'
+                '  var b = document.querySelector(".start-tests-button") ||'
+                '          document.querySelector("#intro button") ||'
+                '          document.querySelector("#home a.start") ||'
+                '          document.querySelector("button");'
+                '  if (!b) {'
+                '    var cand = Array.from(document.querySelectorAll("a, button, [role=button], input[type=button], input[type=submit]"));'
+                '    b = cand.find(function(e){ return /start.*test/i.test((e.textContent||"").trim()); }) ||'
+                '        cand.find(function(e){ return /^\\s*start\\s*$/i.test((e.textContent||"").trim()); });'
+                '  }'
+                '  if (b) { b.click(); return "CLICKED_DOM:" + ((b.textContent||"").trim() || b.outerHTML.substring(0,100)); }'
+                '  return "NO_METHOD:" + e1.message; }'
+            ),
+            'args': []
+        })
+        cv = script_value(r)
+        click_result = str(cv) if cv is not None else 'null'
+        print('SP3_CLICK_' + str(loop_n) + ':' + click_result)
+        if click_result.startswith('NO_METHOD') or click_result == 'null':
+            fail_reason = 'click_no_method'
+            break
+        time.sleep(2)
+
+        # Poll until a final-score element with non-empty text appears. We do not
+        # trust benchmarkClient._isRunning (it toggles per-subtest in SP3 3.1).
+        poll_done = False
+        for poll_n in range(max_polls):
+            r = send_cmd(sock, 'WebDriver:ExecuteScript', {
+                'script': (
+                    'try {'
+                    '  var s = document.querySelector('
+                    '    "#result-number, .score-value, .score, .result-number, '
+                    '    .summary .score, .summary-score"'
+                    '  );'
+                    '  if (s && s.textContent && s.textContent.trim()) {'
+                    '    return "DONE:" + s.textContent.trim();'
+                    '  }'
+                    '  return "RUNNING";'
+                    '} catch(e) { return "ERR:" + e.message; }'
+                ),
+                'args': []
+            })
+            sv = script_value(r)
+            status = str(sv) if sv is not None else 'null'
+            # Reduce poll noise: only log every 6 polls (~30s), at start, and on DONE.
+            if poll_n == 0 or (poll_n % 6 == 0) or status.startswith('DONE:'):
+                print('SP3_POLL_' + str(loop_n) + '_' + str(poll_n) + ':' + status)
+            if status.startswith('DONE:'):
+                if loop_n == 0:
+                    try:
+                        d = send_cmd(sock, 'WebDriver:ExecuteScript', {
+                            'script': (
+                                'try { return JSON.stringify({'
+                                '  url: document.location ? document.location.href : null,'
+                                '  title: document.title,'
+                                '  body: document.body ? (document.body.innerText || "").substring(0, 400) : null'
+                                '}); } catch(e) { return "ERR:" + e.message; }'
+                            ),
+                            'args': []
+                        })
+                        print('SP3_DONE_DIAG:' + str(script_value(d)))
+                    except Exception as ex:
+                        print('SP3_DONE_DIAG_ERROR:' + str(ex))
+                score = status[5:]
+                all_scores.append(score)
+                print('SP3_DONE_' + str(loop_n) + ':' + score)
+                print('SP3_RUN_SECONDS_' + str(loop_n) + ':' + str(poll_n * 5))
+                poll_done = True
+                break
+            time.sleep(5)
+        if not poll_done:
+            print('SP3_POLL_TIMEOUT_' + str(loop_n))
+            fail_reason = 'poll_timeout'
+            break
+
+    # Summary across all loops
+    print('SP3_SCORES_ALL:' + ','.join(all_scores))
+    print('SP3_LOOPS_COMPLETED:' + str(len(all_scores)) + '/' + str(SP3_LOOPS))
+    if all_scores:
+        # Emit a final SP3_DONE/REASON pair so the existing PowerShell parser still works.
+        print('SP3_DONE:' + all_scores[-1])
+        print('SP3_REASON:completed' if len(all_scores) == SP3_LOOPS else ('SP3_REASON:' + (fail_reason or 'partial')))
+    elif fail_reason:
+        print('SP3_REASON:' + fail_reason)
+    else:
+        print('SP3_REASON:no_score')
+
+except Exception as ex:
+    print('MARIONETTE_ERROR:' + str(ex))
+    sys.exit(1)
+finally:
+    if sock:
+        try: sock.close()
+        except: pass
+print('MARIONETTE_DONE')
+'@
+# Inject SP3 iteration count + loop count (baked in at construction time on the local side)
+`$pyContent = `$pyContent.Replace('__SP3_ITERATIONS__', '$sp3_iterations')
+`$pyContent = `$pyContent.Replace('__SP3_LOOPS__',      '$sp3_loops')
+`$pyContent | Set-Content `$pyFile -Encoding UTF8
+
+# --- Pre-clean any leftover ETW sessions from prior crashed runs ---
+# NT Kernel Logger is a singleton session: if a previous xperf -stop didn't run
+# (script killed, host rebooted, etc.) the next xperf -on fails with 0xb7.
+# All native invocations are wrapped in try/catch because under \$ErrorActionPreference=Stop,
+# any stderr output from a native command produces an ErrorRecord that terminates the script
+# even with 2>\$null redirection.
+if (`$xperfOK) {
+    try { `$null = & `$xperfExe -stop 2>`$null } catch {}
+}
+try { `$null = & logman stop `$sessionName -ets 2>`$null } catch {}
+
+# --- Start xperf kernel POWER trace ---
+`$xperfStarted = `$false
+if (`$xperfOK) {
+    try {
+        `$null = & `$xperfExe -on 'PROC_THREAD+LOADER+POWER' -BufferSize 512 -MinBuffers 32 -MaxBuffers 96 -f `$kernelEtl 2>`$null
+        `$xperfStarted = (`$LASTEXITCODE -eq 0)
+    } catch {}
+}
+
+# --- Start logman user-mode ETW: Microsoft-Windows-Kernel-Processor-Power ---
+`$logmanStarted = `$false
+try {
+    `$null = & logman create trace `$sessionName ``
+        -p 'Microsoft-Windows-Kernel-Processor-Power' 0xFFFFFFFFFFFFFFFF 0xff ``
+        -o `$userEtl -max 256 -ets 2>`$null
+    `$logmanStarted = (`$LASTEXITCODE -eq 0)
+} catch {}
+
+# --- Create fresh Firefox profile dir ---
+if (-not (Test-Path `$ffProfile)) { New-Item -ItemType Directory `$ffProfile -Force | Out-Null }
+
+# --- Detect active interactive task user (non-Administrator) via `query user` ---
+`$taskUser    = `$null
+`$taskSession = `$null
+try {
+    `$qu = & query user 2>`$null
+    foreach (`$line in `$qu) {
+        # Active rows look like:  ">user-name              console     1   Active   .  date"
+        # The leading ">" marks the current session (Administrator running this script).
+        if (`$line -match '^\s*>?\s*(\S+)\s+\S+\s+(\d+)\s+Active') {
+            `$u = `$matches[1]
+            `$s = [int]`$matches[2]
+            if (`$u -notmatch '^(Administrator|administrator|SYSTEM)$' -and `$u -ne `$env:USERNAME) {
+                `$taskUser    = `$u
+                `$taskSession = `$s
+                break
+            }
+        }
+    }
+} catch {}
+
+# --- Start Firefox headless with Marionette ---
+# Launches in the task user's interactive session via a one-shot scheduled task
+# (LogonType=Interactive uses the user's existing logon token — no password needed).
+# Falls back to Start-Process in the Administrator session if no task user is logged in.
+`$ffStarted    = `$false
+`$ffProc       = `$null
+`$ffLaunchMode = 'none'
+if (`$ffOK) {
+    `$ffArgs = '$(if ($visible) { "" } else { "--headless " })--marionette --no-remote --new-instance -profile ' + `$ffProfile
+    if (`$taskUser) {
+        try {
+            `$ffLaunchMode = 'scheduled_task'
+            `$action    = New-ScheduledTaskAction -Execute `$ffExe -Argument `$ffArgs
+            `$principal = New-ScheduledTaskPrincipal -UserId "`$env:COMPUTERNAME\`$taskUser" -LogonType Interactive
+            `$settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit (New-TimeSpan -Hours 1)
+            `$taskDef   = New-ScheduledTask -Action `$action -Principal `$principal -Settings `$settings
+            Register-ScheduledTask -TaskName `$ffSchedTask -InputObject `$taskDef -Force | Out-Null
+            Start-ScheduledTask -TaskName `$ffSchedTask
+            # Poll up to 15s for an actual firefox.exe to appear in a non-zero session.
+            for (`$w = 0; `$w -lt 15; `$w++) {
+                Start-Sleep -Seconds 1
+                `$candidates = Get-Process firefox -ErrorAction SilentlyContinue
+                if (`$candidates) { `$ffStarted = `$true; break }
+            }
+        } catch {
+            `$ffLaunchMode = "scheduled_task_failed:`$(`$_.Exception.Message -replace "`r`n",' ')"
+        }
+    } else {
+        `$ffLaunchMode = 'admin_fallback'
+        `$ffProc = Start-Process -FilePath `$ffExe -ArgumentList `$ffArgs -WindowStyle Hidden -PassThru -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 8
+        `$ffStarted = (`$null -ne `$ffProc -and -not `$ffProc.HasExited)
+    }
+}
+
+# --- Start Marionette Python script as a background process ---
+# It navigates to SP3, clicks Start, and polls until the benchmark finishes.
+# Note: Start-Process refuses if stdout and stderr point to the same path, so we
+# use two files and merge them after the process exits.
+`$pyProc    = `$null
+`$pyStarted = `$false
+if (`$ffStarted -and `$pythonFound -and (Test-Path `$pyFile)) {
+    try {
+        `$pyProc = Start-Process -FilePath `$pythonExe -ArgumentList `$pyFile ``
+            -RedirectStandardOutput `$pyOutFile -RedirectStandardError `$pyErrFile ``
+            -WindowStyle Hidden -PassThru -ErrorAction Stop
+        `$pyStarted = (`$null -ne `$pyProc)
+    } catch {
+        `$pyStartError = `$_.Exception.Message -replace "`r`n",' '
+    }
+}
+
+# --- CPU sampling loop ---
+# Runs until the Marionette script exits (SP3 done) or `$dur seconds elapse (safety cap).
+`$t0         = Get-Date
+`$cpuSamples = [System.Collections.Generic.List[double]]::new()
+`$deadline   = `$t0.AddSeconds(`$dur)
+`$ffCrashed = `$false
+while ((Get-Date) -lt `$deadline) {
+    if (`$null -ne `$pyProc -and `$pyProc.HasExited) { break }
+    # Firefox-crash check: works for both Start-Process (admin fallback) and scheduled-task launch
+    if (`$ffStarted) {
+        `$ffAlive = @(Get-Process firefox -ErrorAction SilentlyContinue).Count -gt 0
+        if (-not `$ffAlive) { `$ffCrashed = `$true; break }
+    }
+    try {
+        `$ctr = (Get-Counter '\Processor(_Total)\% Processor Time' -ErrorAction Stop).CounterSamples[0].CookedValue
+        `$cpuSamples.Add([math]::Round(`$ctr, 1))
+    } catch {}
+    Start-Sleep -Seconds 4
+}
+`$t1 = Get-Date
+
+# --- Read Marionette output (merge stdout and stderr) ---
+`$marionetteOut = ''
+`$pyExitCode   = `$null
+# Give Python up to 5s to flush its output file if it just exited
+if (`$null -ne `$pyProc -and -not `$pyProc.HasExited) {
+    `$null = `$pyProc.WaitForExit(5000)
+}
+if (`$null -ne `$pyProc) { `$pyExitCode = `$pyProc.ExitCode }
+# Get-Content -Raw returns \$null on an empty file in PS 5.1 (not empty string),
+# so we must null-check before calling .Trim().
+if (Test-Path `$pyOutFile) {
+    `$rawOut = Get-Content `$pyOutFile -Raw -ErrorAction SilentlyContinue
+    if (`$rawOut) { `$marionetteOut = `$rawOut.Trim() }
+}
+if (Test-Path `$pyErrFile) {
+    `$rawErr = Get-Content `$pyErrFile -Raw -ErrorAction SilentlyContinue
+    if (`$rawErr) {
+        `$errContent = `$rawErr.Trim()
+        if (`$marionetteOut) { `$marionetteOut += "`n--- STDERR ---`n" + `$errContent }
+        else                 { `$marionetteOut  = "--- STDERR ---`n" + `$errContent }
+    }
+}
+
+`$sp3Started  = `$marionetteOut -match 'STARTED_API|CLICKED_DOM'
+`$sp3Finished = `$marionetteOut -match 'SP3_DONE:'
+`$sp3ScoreM   = [regex]::Match(`$marionetteOut, 'SP3_DONE:(\S+)')
+`$sp3Score    = if (`$sp3ScoreM.Success) { `$sp3ScoreM.Groups[1].Value.Trim() } else { '' }
+`$sp3AllM     = [regex]::Match(`$marionetteOut, 'SP3_SCORES_ALL:(\S*)')
+`$sp3AllScores = if (`$sp3AllM.Success) { `$sp3AllM.Groups[1].Value.Trim() } else { '' }
+`$sp3LoopsM   = [regex]::Match(`$marionetteOut, 'SP3_LOOPS_COMPLETED:(\S+)')
+`$sp3Loops    = if (`$sp3LoopsM.Success) { `$sp3LoopsM.Groups[1].Value.Trim() } else { '' }
+`$sp3ReasonM  = [regex]::Match(`$marionetteOut, 'SP3_REASON:(\S+)')
+`$sp3Reason   = if (`$sp3ReasonM.Success) { `$sp3ReasonM.Groups[1].Value.Trim() }
+               elseif (`$ffCrashed)        { 'firefox_crashed' }
+               elseif (`$marionetteOut -match 'MARIONETTE_CONNECT_FAILED') { 'marionette_connect_failed' }
+               elseif (-not `$marionetteOut) { 'no_marionette_output' }
+               else                          { 'unknown' }
+
+# --- Kill Marionette Python if still running (safety cap hit) ---
+if (`$null -ne `$pyProc -and -not `$pyProc.HasExited) {
+    Stop-Process -Id `$pyProc.Id -Force -ErrorAction SilentlyContinue
+}
+
+# --- Kill Firefox and clean up its profile + scheduled task ---
+if (`$null -ne `$ffProc) {
+    Stop-Process -Id `$ffProc.Id -Force -ErrorAction SilentlyContinue
+}
+Get-Process -Name firefox -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+try { Unregister-ScheduledTask -TaskName `$ffSchedTask -Confirm:`$false -ErrorAction SilentlyContinue } catch {}
+Remove-Item `$ffProfile -Recurse -Force -ErrorAction SilentlyContinue
+
+# --- Stop xperf (correct cleanup is `-stop`; `-d` requires a file arg and is for a different mode) ---
+`$xperfStopOK = `$false
+if (`$xperfOK -and `$xperfStarted) {
+    try {
+        `$null = & `$xperfExe -stop 2>`$null
+        `$xperfStopOK = (`$LASTEXITCODE -eq 0)
+    } catch {}
+}
+
+# --- Stop logman ---
+if (`$logmanStarted) {
+    try { `$null = & logman stop `$sessionName -ets 2>`$null } catch {}
+}
+
+# --- System event log: Ev37/55 ---
+`$evs = try {
+    Get-WinEvent -FilterHashtable @{
+        LogName      = 'System'
+        ProviderName = 'Microsoft-Windows-Kernel-Processor-Power'
+        StartTime    = `$t0; EndTime = `$t1
+    } -ErrorAction Stop | Where-Object { `$_.Id -in 37, 55 }
+} catch { @() }
+`$e37 = @(`$evs | Where-Object { `$_.Id -eq 37 })
+`$e55 = @(`$evs | Where-Object { `$_.Id -eq 55 })
+
+`$byp = `$e37 |
+    Group-Object { ([regex]::Match(`$_.Message, '(?i)processor\s+(\d+)')).Groups[1].Value } |
+    Sort-Object { [int]`$_.Name } |
+    ForEach-Object { [pscustomobject]@{ Proc = `$_.Name; Count = `$_.Count } }
+`$bpj = if (`$byp) { `$byp | ConvertTo-Json -Compress } else { '[]' }
+
+`$p55 = foreach (`$x in `$e55) {
+    `$m  = `$x.Message
+    `$pc = ([regex]::Match(`$m, '(?i)processor\s+(\d+)')).Groups[1].Value
+    `$mp = ([regex]::Match(`$m, 'Minimum performance percentage:\s+(\d+)')).Groups[1].Value
+    if (`$pc -and `$mp) { [pscustomobject]@{ Proc = [int]`$pc; MinPct = [int]`$mp } }
+}
+`$wst = if (`$p55) { (`$p55 | Measure-Object MinPct -Minimum).Minimum } else { `$null }
+`$avg = if (`$p55) { [math]::Round((`$p55 | Measure-Object MinPct -Average).Average, 1) } else { `$null }
+
+# --- Parse logman ETL: counts of throttling-related event IDs only ---
+# Use FilterXPath so Get-WinEvent only materializes the events we care about.
+# Reading every event in the ETL (1.5M+ for a 12-loop run) takes 10+ minutes
+# and previously caused SSH timeouts before the result JSON could be emitted.
+`$xEv37 = 0; `$xEv48 = 0; `$xEv51 = 0; `$xEv55 = 0; `$xEv58 = 0
+`$xEv48MinPct = `$null; `$xEv51MinPct = `$null
+`$xEvOther = ''; `$xEvError = ''
+if (`$logmanStarted -and (Test-Path `$userEtl)) {
+    try {
+        `$xpath = "*[System[(EventID=37 or EventID=48 or EventID=51 or EventID=55 or EventID=58)]]"
+        `$relevantEvts = @(Get-WinEvent -Path `$userEtl -Oldest -FilterXPath `$xpath -ErrorAction Stop |
+            Where-Object { `$_.TimeCreated -ge `$t0 -and `$_.TimeCreated -le `$t1 })
+        `$xEv37 = @(`$relevantEvts | Where-Object { `$_.Id -eq 37 }).Count
+        `$xEv48 = @(`$relevantEvts | Where-Object { `$_.Id -eq 48 }).Count
+        `$xEv51 = @(`$relevantEvts | Where-Object { `$_.Id -eq 51 }).Count
+        `$xEv55 = @(`$relevantEvts | Where-Object { `$_.Id -eq 55 }).Count
+        `$xEv58 = @(`$relevantEvts | Where-Object { `$_.Id -eq 58 }).Count
+        foreach (`$ev in (`$relevantEvts | Where-Object { `$_.Id -eq 48 })) {
+            `$mp = ([regex]::Match(`$ev.Message, 'Minimum performance percentage:\s+(\d+)')).Groups[1].Value
+            if (`$mp) { `$v = [int]`$mp; if (`$null -eq `$xEv48MinPct -or `$v -lt `$xEv48MinPct) { `$xEv48MinPct = `$v } }
+        }
+        foreach (`$ev in (`$relevantEvts | Where-Object { `$_.Id -eq 51 })) {
+            `$mp = ([regex]::Match(`$ev.Message, 'Minimum performance percentage:\s+(\d+)')).Groups[1].Value
+            if (`$mp) { `$v = [int]`$mp; if (`$null -eq `$xEv51MinPct -or `$v -lt `$xEv51MinPct) { `$xEv51MinPct = `$v } }
+        }
+    } catch { `$xEvError = `$_.ToString() -replace "`r`n",' ' }
+}
+
+# --- xperf cpufreq analysis ---
+`$xFreqSummary = ''; `$xFreqError = ''
+if (`$xperfOK -and `$xperfStopOK -and (Test-Path `$kernelEtl)) {
+    try {
+        `$rawFreq = & `$xperfExe -i `$kernelEtl -a cpufreq 2>&1
+        `$freqMap = @{}
+        foreach (`$line in `$rawFreq) {
+            `$m = [regex]::Match(`$line, '(\d{3,5})\s+(\d+\.\d+)')
+            if (`$m.Success) {
+                `$mhz = [int]`$m.Groups[1].Value
+                `$pct = [double]`$m.Groups[2].Value
+                if (`$freqMap.ContainsKey(`$mhz)) { `$freqMap[`$mhz] += `$pct } else { `$freqMap[`$mhz] = `$pct }
+            }
+        }
+        if (`$freqMap.Count -gt 0) {
+            `$xFreqSummary = (`$freqMap.GetEnumerator() | Sort-Object Key -Descending |
+                ForEach-Object { "`$(`$_.Key)MHz:`$([math]::Round(`$_.Value/`$freqMap.Count,1))%" }) -join ' | '
+        } else {
+            `$xFreqSummary = ((`$rawFreq -join ' | ') -replace '\s+',' ').Substring(0, [math]::Min(2000,((`$rawFreq -join ' | ').Length)))
+        }
+    } catch { `$xFreqError = `$_.ToString() -replace "`r`n",' ' }
+}
+
+# --- Cleanup ---
+Remove-Item `$kernelEtl  -Force -ErrorAction SilentlyContinue
+Remove-Item `$userEtl    -Force -ErrorAction SilentlyContinue
+Remove-Item `$pyFile     -Force -ErrorAction SilentlyContinue
+Remove-Item `$pyOutFile  -Force -ErrorAction SilentlyContinue
+Remove-Item `$pyErrFile  -Force -ErrorAction SilentlyContinue
+
+# --- Choco uninstall Firefox (only if we installed it) ---
+`$chocoUninstall = `$false
+if (`$chocoInstall) {
+    try   { `$null = & choco uninstall firefox --yes --no-progress --limit-output 2>&1 } catch {}
+    `$chocoUninstall = (`$LASTEXITCODE -eq 0)
+}
+
+# --- RAM inventory ---
+`$totalMem   = [long](Get-WmiObject Win32_ComputerSystem).TotalPhysicalMemory
+`$ramDimms   = @(Get-WmiObject Win32_PhysicalMemory)
+`$ramSlots   = `$ramDimms.Count
+`$ramTotalGB = [math]::Round(`$totalMem / 1GB, 1)
+`$ramSpeeds  = (`$ramDimms | ForEach-Object { `$_.Speed } | Sort-Object -Unique) -join '/'
+`$ramSizes   = (`$ramDimms | ForEach-Object { [math]::Round(`$_.Capacity / 1GB, 0) }) -join '+'
+`$ramChannel = if (`$ramSlots -ge 2) { 'dual' } else { 'single' }
+
+# --- Build result ---
+`$sec = [math]::Round((`$t1 - `$t0).TotalSeconds, 2)
+`$cn  = (Get-WmiObject Win32_Processor | Select-Object -First 1).Name
+`$nc  = [Environment]::ProcessorCount
+
+[pscustomobject]@{
+    Status          = 'ok'
+    Hostname        = `$env:COMPUTERNAME
+    Timestamp       = `$t0.ToString('s')
+    CPU             = `$cn
+    Cores           = `$nc
+    RAM_GB          = `$ramTotalGB
+    RAM_Slots       = `$ramSlots
+    RAM_Channel     = `$ramChannel
+    RAM_SpeedMHz    = `$ramSpeeds
+    RAM_Config      = `$ramSizes
+    DurSec          = `$dur
+    ActSec          = `$sec
+    CPU_MinPct      = if (`$cpuSamples.Count -gt 0) { [math]::Round((`$cpuSamples | Measure-Object -Minimum).Minimum, 1) } else { `$null }
+    CPU_MaxPct      = if (`$cpuSamples.Count -gt 0) { [math]::Round((`$cpuSamples | Measure-Object -Maximum).Maximum, 1) } else { `$null }
+    CPU_AvgPct      = if (`$cpuSamples.Count -gt 0) { [math]::Round((`$cpuSamples | Measure-Object -Average).Average, 1) } else { `$null }
+    CPU_Samples     = `$cpuSamples -join ','
+    Choco_Install   = `$chocoInstall
+    Choco_Output    = (`$chocoOutput -replace "`r`n",' ')
+    FF_AlreadyHere  = `$ffAlreadyHere
+    FF_OK           = `$ffOK
+    FF_Started      = `$ffStarted
+    FF_LaunchMode   = `$ffLaunchMode
+    TaskUser        = `$taskUser
+    TaskSession     = `$taskSession
+    Python_Found    = `$pythonFound
+    Python_Exe      = `$pythonExe
+    Python_Started  = `$pyStarted
+    Python_ExitCode = `$pyExitCode
+    SP3_Started     = `$sp3Started
+    SP3_Finished    = `$sp3Finished
+    SP3_Score       = `$sp3Score
+    SP3_AllScores   = `$sp3AllScores
+    SP3_Loops       = `$sp3Loops
+    SP3_Reason      = `$sp3Reason
+    FF_Crashed      = `$ffCrashed
+    Marionette_Out  = (`$marionetteOut -replace "`r`n",' ')
+    Choco_Uninstall = `$chocoUninstall
+    Ev37            = `$e37.Count
+    Ev37_ByProc     = `$bpj
+    Ev55            = `$e55.Count
+    Ev55_Worst      = `$wst
+    Ev55_Avg        = `$avg
+    Xperf_OK        = `$xperfOK
+    Xperf_Started   = `$xperfStarted
+    Logman_OK       = `$logmanStarted
+    XEv37           = `$xEv37
+    XEv48           = `$xEv48
+    XEv51           = `$xEv51
+    XEv55           = `$xEv55
+    XEv58           = `$xEv58
+    XEv_Other       = `$xEvOther
+    XEv48_MinPct    = `$xEv48MinPct
+    XEv51_MinPct    = `$xEv51MinPct
+    XFreq_Summary   = `$xFreqSummary
+    XFreq_Error     = `$xFreqError
+    XEv_Error       = `$xEvError
+} | ConvertTo-Json -Depth 5 -Compress
+"@
+
+# ------------------ Test-remote override (small payload to bisect transport vs. real payload) ------------------
+if ($test_remote) {
+    $stressPayload = @"
+[pscustomobject]@{
+    Status     = 'ok_test'
+    Hostname   = `$env:COMPUTERNAME
+    PSVersion  = `$PSVersionTable.PSVersion.ToString()
+    Now        = (Get-Date).ToString('s')
+    PayloadLen = 999
+} | ConvertTo-Json -Compress
+"@
+    Write-Host "TEST_REMOTE: using minimal payload to verify SSH+EncodedCommand transport"
+}
+
+# ------------------ Parallel runner ------------------
+function Invoke-Parallel {
+    param([string[]]$Fqdns, [switch]$IsRetry)
+
+    $rsPool   = [RunspaceFactory]::CreateRunspacePool(1, [math]::Max(1, $max_parallel))
+    $rsPool.Open()
+    $msgQueue = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
+
+    $rsScript = {
+        param(
+            [string]$Fqdn,
+            [string]$StressPayload,
+            [int]$DurationSecs,
+            [int]$SshTimeoutSecs,
+            [bool]$DryRun,
+            [string]$SshUser,
+            [System.Collections.Concurrent.ConcurrentQueue[string]]$MsgQueue
+        )
+
+        function Log { param([string]$Msg) $MsgQueue.Enqueue($Msg) }
+
+        function Invoke-SSH {
+            param([string]$NodeName, [string]$Command, [int]$TimeoutSec = 600, [string]$StdinText = "")
+            $target = if ($NodeName -match '@') { $NodeName } else { "$SshUser@$NodeName" }
+            $psi = [System.Diagnostics.ProcessStartInfo]::new('ssh')
+            $psi.Arguments              = "-o ConnectTimeout=15 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no $target $Command"
+            $psi.UseShellExecute        = $false
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError  = $true
+            $psi.RedirectStandardInput  = $true
+            $psi.CreateNoWindow         = $true
+            $p = [System.Diagnostics.Process]::Start($psi)
+            $outTask = $p.StandardOutput.ReadToEndAsync()
+            $errTask = $p.StandardError.ReadToEndAsync()
+            if ($StdinText) { $p.StandardInput.Write($StdinText) }
+            $p.StandardInput.Close()
+            $exited  = $p.WaitForExit($TimeoutSec * 1000)
+            if (-not $exited) { try { $p.Kill() } catch {} }
+            $null = $outTask.Wait(10000)
+            $null = $errTask.Wait(10000)
+            $stdout   = if ($outTask.Status -eq 'RanToCompletion') { $outTask.Result } else { '' }
+            $stderr   = if ($errTask.Status -eq 'RanToCompletion') { $errTask.Result } else { '' }
+            $exitCode = if ($exited) { $p.ExitCode } else { 255 }
+            $p.Dispose()
+            [pscustomobject]@{ Output = $stdout; Error = $stderr; ExitCode = $exitCode }
+        }
+        function Invoke-SSHPS {
+            param([string]$NodeName, [string]$PsCommand)
+            $remoteName = "stress_payload_$([guid]::NewGuid().ToString('N')).ps1"
+            $localTemp  = Join-Path $env:TEMP $remoteName
+            Set-Content -Path $localTemp -Value $PsCommand -Encoding UTF8
+
+            $scpTarget = if ($NodeName -match '@') { $NodeName } else { "$SshUser@$NodeName" }
+            Log ("[$NodeName] payload={0}B  remote={1}  user={2}" -f $PsCommand.Length, $remoteName, $SshUser)
+
+            try {
+                $scpArgs = "-O -o ConnectTimeout=15 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no `"$localTemp`" `"${scpTarget}:$remoteName`""
+                $psi = [System.Diagnostics.ProcessStartInfo]::new('scp')
+                $psi.Arguments              = $scpArgs
+                $psi.UseShellExecute        = $false
+                $psi.RedirectStandardOutput = $true
+                $psi.RedirectStandardError  = $true
+                $psi.CreateNoWindow         = $true
+                $sp = [System.Diagnostics.Process]::Start($psi)
+                $scpOut = $sp.StandardOutput.ReadToEnd()
+                $scpErr = $sp.StandardError.ReadToEnd()
+                $null = $sp.WaitForExit(60000)
+                $scpExit = $sp.ExitCode
+                $sp.Dispose()
+                if ($scpExit -ne 0) {
+                    return [pscustomobject]@{ Output = ''; Error = "scp failed (exit $scpExit): $scpOut $scpErr"; ExitCode = 254 }
+                }
+
+                $remoteCmd = "powershell -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File `"`$env:USERPROFILE\$remoteName`"; Remove-Item `"`$env:USERPROFILE\$remoteName`" -Force -ErrorAction SilentlyContinue"
+                Invoke-SSH -NodeName $NodeName -TimeoutSec $SshTimeoutSecs -Command $remoteCmd
+            } finally {
+                Remove-Item $localTemp -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        if ($DryRun) { Log "[$Fqdn] DRY RUN"; return [pscustomobject]@{ _s = 'dry'; Fqdn = $Fqdn } }
+
+        Log "[$Fqdn] Connecting..."
+        $res = Invoke-SSHPS -NodeName $Fqdn -PsCommand $StressPayload
+        $out = ($res.Output | Out-String).Trim()
+        $err = if ($res.PSObject.Properties['Error']) { ($res.Error | Out-String).Trim() } else { '' }
+
+        if ($err) {
+            $errSnippet = if ($err.Length -gt 2000) { $err.Substring(0, 2000) + "...[truncated]" } else { $err }
+            Log "[$Fqdn] RAW STDERR (len=$($err.Length)): $errSnippet"
+        }
+
+        if ($res.ExitCode -eq 255) { Log "[$Fqdn] SSH connection failed.";                return [pscustomobject]@{ _s = 'err'; Fqdn = $Fqdn } }
+        if ($res.ExitCode -ne 0)   { Log "[$Fqdn] Remote failed (exit $($res.ExitCode))."; return [pscustomobject]@{ _s = 'err'; Fqdn = $Fqdn } }
+
+        $rawSnippet = if ($out.Length -gt 1500) { $out.Substring(0, 1500) + "...[truncated]" } else { $out }
+        Log "[$Fqdn] RAW STDOUT (len=$($out.Length)): $rawSnippet"
+
+        if ([string]::IsNullOrWhiteSpace($out)) {
+            Log "[$Fqdn] Remote returned empty stdout with exit 0 (stderr above, if any)."
+            return [pscustomobject]@{ _s = 'err'; Fqdn = $Fqdn }
+        }
+
+        try   { $obj = $out | ConvertFrom-Json }
+        catch { Log "[$Fqdn] No JSON in output.`n$out"; return [pscustomobject]@{ _s = 'err'; Fqdn = $Fqdn } }
+
+        if ($obj.Status -eq 'busy') { Log "[$Fqdn] Busy (task running)."; return [pscustomobject]@{ _s = 'busy'; Fqdn = $Fqdn } }
+
+        Log ("[$Fqdn] Done  Ev37={0}  CPU_Min={1}%  CPU_Avg={2}%  XEv37={3}  XEv48={4}  XEv51={5}  XEv58={6}  FF={7}  Mode={8}  TaskUser={9}  SP3_Done={10}  Reason={11}  Score={12}  Loops={13}  Scores=[{14}]  ActSec={15}" -f
+            $obj.Ev37, $obj.CPU_MinPct, $obj.CPU_AvgPct,
+            $obj.XEv37, $obj.XEv48, $obj.XEv51, $obj.XEv58,
+            $obj.FF_Started, $obj.FF_LaunchMode, $obj.TaskUser,
+            $obj.SP3_Finished, $obj.SP3_Reason, $obj.SP3_Score,
+            $obj.SP3_Loops, $obj.SP3_AllScores, $obj.ActSec)
+        if ($obj.XFreq_Summary)  { Log "[$Fqdn] CpuFreq: $($obj.XFreq_Summary)" }
+        if ($obj.Marionette_Out) { Log "[$Fqdn] Marionette: $($obj.Marionette_Out)" }
+        if ($obj.XEv_Error)      { Log "[$Fqdn] ETL parse error: $($obj.XEv_Error)" }
+        if ($obj.XFreq_Error)    { Log "[$Fqdn] cpufreq error: $($obj.XFreq_Error)" }
+        return $obj
+    }
+
+    function Drain-Queue {
+        $msg = $null
+        while ($msgQueue.TryDequeue([ref]$msg)) { Write-Host $msg; $msg = $null }
+    }
+
+    $totalBatches = [math]::Ceiling($Fqdns.Count / $max_parallel)
+    $batchNum     = 0
+
+    for ($i = 0; $i -lt $Fqdns.Count; $i += $max_parallel) {
+        $batchNum++
+        $batch = $Fqdns[$i..[math]::Min($i + $max_parallel - 1, $Fqdns.Count - 1)]
+
+        Write-Host ""
+        Write-Host ("  -- Batch {0}/{1}  ({2} node(s)) --" -f $batchNum, $totalBatches, $batch.Count)
+
+        $jobs = [System.Collections.Generic.List[object]]::new()
+        foreach ($fqdn in $batch) {
+            $ps = [PowerShell]::Create()
+            $ps.RunspacePool = $rsPool
+            [void]$ps.AddScript($rsScript)
+            [void]$ps.AddParameters(@{
+                Fqdn           = $fqdn
+                StressPayload  = $stressPayload
+                DurationSecs   = $duration_secs
+                SshTimeoutSecs = $ssh_timeout_secs
+                DryRun         = [bool]$dry_run
+                SshUser        = $ssh_user
+                MsgQueue       = $msgQueue
+            })
+            $jobs.Add([pscustomobject]@{ PS = $ps; Handle = $ps.BeginInvoke(); Fqdn = $fqdn })
+        }
+
+        $pending       = [System.Collections.Generic.List[object]]::new($jobs)
+        $lastHeartbeat = [datetime]::Now
+        while ($pending.Count -gt 0) {
+            Drain-Queue
+            if (([datetime]::Now - $lastHeartbeat).TotalSeconds -ge 30) {
+                Write-Host ("  [waiting] Batch {0}/{1}: {2} node(s) still running..." -f $batchNum, $totalBatches, $pending.Count)
+                $lastHeartbeat = [datetime]::Now
+            }
+            $done = @($pending | Where-Object { $_.Handle.IsCompleted })
+            foreach ($job in $done) {
+                [void]$pending.Remove($job)
+                try   { $r = $job.PS.EndInvoke($job.Handle)[0] }
+                catch { $msgQueue.Enqueue("[$($job.Fqdn)] Runspace error: $_"); $r = [pscustomobject]@{ _s = 'err'; Fqdn = $job.Fqdn } }
+                $job.PS.Dispose()
+
+                $rs = if ($r -and $r.PSObject.Properties['_s']) { $r._s } else { $null }
+                if     ($null -eq $r -or $rs -eq 'dry')  { }
+                elseif ($rs -eq 'err')                    { if ($script:failed_ssh  -notcontains $job.Fqdn) { $script:failed_ssh  += $job.Fqdn } }
+                elseif ($rs -eq 'busy')                   { if ($script:busy_nodes  -notcontains $job.Fqdn) { $script:busy_nodes  += $job.Fqdn } }
+                else {
+                    $script:results += $r
+                    if ($IsRetry -and $script:retry_recovered -notcontains $job.Fqdn) { $script:retry_recovered += $job.Fqdn }
+                }
+            }
+            if ($pending.Count -gt 0) { Start-Sleep -Milliseconds 250 }
+        }
+        Drain-Queue
+    }
+
+    $rsPool.Close()
+    $rsPool.Dispose()
+}
+
+# ------------------ PASS 1 ------------------
+Write-Host ""
+Write-Host "------------------------------------------------------------"
+Write-Host "     STRESS + SP3 FULL RUN + ETW POWER CAPTURE              "
+Write-Host ("   Nodes: {0}   Batches of: {1}   Max wait: {2}s   Dry run: {3}" -f $targets.Count, $max_parallel, $duration_secs, $dry_run)
+Write-Host "------------------------------------------------------------"
+Write-Host ""
+Write-Host "Target nodes:"
+$target_shorts | ForEach-Object { Write-Host "  $_" }
+Write-Host ""
+
+Invoke-Parallel -Fqdns $targets
+
+# ------------------ Busy retry loop ------------------
+$busyPass = 0
+while (-not $no_retry -and $script:busy_nodes.Count -gt 0) {
+    $busyPass++
+    $pending           = @($script:busy_nodes | Sort-Object -Unique)
+    $script:busy_nodes = @()
+    Sleep-BetweenPasses -Seconds $retry_sleep_secs -Label "busy retry $busyPass - $($pending.Count) node(s)"
+    Write-Host "---- BUSY RETRY $busyPass ($($pending.Count) node(s)) ----"
+    Invoke-Parallel -Fqdns $pending
+}
+
+# ------------------ SSH retry loop ------------------
+$sshPass = 0
+while (-not $no_retry -and $script:failed_ssh.Count -gt 0 -and $sshPass -lt $ssh_max_retries) {
+    $sshPass++
+    $retry             = @($script:failed_ssh | Sort-Object -Unique)
+    $script:failed_ssh = @()
+    Sleep-BetweenPasses -Seconds $retry_sleep_secs -Label "SSH retry $sshPass of $ssh_max_retries - $($retry.Count) node(s)"
+    Write-Host "---- SSH RETRY $sshPass of $ssh_max_retries ($($retry.Count) node(s)) ----"
+    Invoke-Parallel -Fqdns $retry -IsRetry
+
+    while ($script:busy_nodes.Count -gt 0) {
+        $busyPass++
+        $pending           = @($script:busy_nodes | Sort-Object -Unique)
+        $script:busy_nodes = @()
+        Sleep-BetweenPasses -Seconds $retry_sleep_secs -Label "busy retry $busyPass (during SSH retry)"
+        Invoke-Parallel -Fqdns $pending
+    }
+}
+
+# ------------------ CSV output ------------------
+$outCsv = Join-Path $output_dir ("stress_sp3_list-{0}nodes_{1}.csv" -f $targets.Count, $script:stamp)
+
+if ($dry_run) {
+    Write-Host "DRY RUN: would write CSV to $outCsv"
+} else {
+    $okHosts = @($script:results | ForEach-Object { $_.Hostname }) | Sort-Object -Unique
+    foreach ($fqdn in @($targets | Sort-Object -Unique)) {
+        $short = $fqdn -replace ("\." + [regex]::Escape($domain_suffix) + "$"), ""
+        if ($okHosts -notcontains $short -and $okHosts -notcontains $fqdn) {
+            $script:results += [pscustomobject]@{
+                Hostname  = $short
+                Timestamp = (Get-Date).ToString("s")
+                Error     = "No result after $ssh_max_retries SSH retries"
+            }
+        }
+    }
+    $script:results | Export-Csv -Path $outCsv -NoTypeInformation -Encoding UTF8
+    Write-Host "CSV : $outCsv"
+}
+
+# ------------------ Summary ------------------
+Write-Host ""
+Write-Host "==== SUMMARY ===="
+Write-Host ("Max wait per node : {0}s" -f $duration_secs)
+Write-Host ("Nodes targeted    : {0}"  -f $targets.Count)
+Write-Host ""
+
+$good = @($script:results | Where-Object { -not $_.PSObject.Properties['Error'] })
+if ($good.Count -gt 0) {
+    $good |
+        Select-Object Hostname, ActSec, CPU_MinPct, CPU_AvgPct, SP3_Finished, SP3_Reason, SP3_Score,
+                      SP3_Loops, SP3_AllScores,
+                      Ev37, Ev55_Worst, XEv37, XEv48, XEv51, XEv58,
+                      XEv48_MinPct, XEv51_MinPct, Xperf_OK, Logman_OK, FF_Started, FF_Crashed,
+                      FF_LaunchMode, TaskUser, TaskSession |
+        Sort-Object @{e='Ev37';d=1}, @{e='XEv48';d=1} |
+        Format-Table -AutoSize |
+        Out-String |
+        Write-Host
+}
+
+if (@($script:failed_ssh).Count -gt 0) {
+    Write-Host "Failed (after all retries):"
+    $script:failed_ssh | Sort-Object -Unique | ForEach-Object { Write-Host "  - $_" }
+} else {
+    Write-Host "Failed: none"
+}
+
+if (@($script:retry_recovered).Count -gt 0) {
+    Write-Host ""
+    Write-Host "Recovered on retry:"
+    $script:retry_recovered | Sort-Object -Unique | ForEach-Object { Write-Host "  - $_" }
+}
+
+Write-Host ""
+Write-Host "Log : $logFile"
+Write-Host "CSV : $outCsv"
+
+Stop-Transcript

--- a/provisioners/windows/MDC1Windows/utility_scripts/stress_test/UninstallFirefox.ps1
+++ b/provisioners/windows/MDC1Windows/utility_scripts/stress_test/UninstallFirefox.ps1
@@ -1,0 +1,459 @@
+# UninstallFirefox.ps1
+# Fleet-wide cleanup of Firefox installs that StressSP3.ps1 may have left behind.
+#
+# StressSP3.ps1's payload only installs Firefox via Chocolatey when firefox.exe
+# is not already present, and only uninstalls it on the SAME run if that install
+# succeeded. If a run was killed (SSH timeout, Ctrl-C, host reboot, etc.) before
+# the uninstall step, Firefox can be left installed on the node. This script
+# walks the fleet and uninstalls those.
+#
+# Default behavior is conservative: only uninstall Firefox if Chocolatey reports
+# it as a managed package on the node ({{choco list --local-only firefox}}). If
+# Firefox was installed manually or by an MSI image, choco won't know about it
+# and we'll leave it alone. Pass -force to uninstall regardless.
+#
+# Per node:
+#   - busy check (skip if generic-worker has a task running)
+#   - kill any leftover firefox.exe and unregister our StressSP3_FF_* tasks
+#   - check whether Chocolatey manages firefox
+#   - choco uninstall firefox  (if managed, or if -force)
+#   - verify firefox.exe is gone, report status
+#
+# Output: CSV at C:\logs\uninstall_firefox_<N>nodes_<stamp>.csv
+#         JSON at the same path
+#
+# Same fleet-orchestration pattern as Scan-NUCHealth.ps1 / StressSP3-Fleet.ps1:
+# range mode default 1..160, 18-node skip list, 3-pass SSH retry with 120s
+# sleep, busy-skip-with-retry, parallel batches.
+#
+# Usage:
+#   .\UninstallFirefox.ps1                                    # default sweep, conservative
+#   .\UninstallFirefox.ps1 -dry_run                           # show what would happen
+#   .\UninstallFirefox.ps1 -force                             # uninstall even if not choco-managed
+#   .\UninstallFirefox.ps1 -nodes "nuc13-029,nuc13-077"       # subset
+#   .\UninstallFirefox.ps1 -range_start 1 -range_end 50       # range subset
+#   .\UninstallFirefox.ps1 -no_skip                           # disable skip list
+
+param(
+    [int]$range_start      = 1,
+    [int]$range_end        = 160,
+    [int]$range_pad        = 3,
+    [string]$range_prefix  = "nuc13",
+    [string]$nodes         = "",
+    [switch]$single,
+    [string]$node          = "",
+    [string]$ssh_user      = "Administrator",
+    [string]$domain_suffix = "wintest2.releng.mdc1.mozilla.com",
+    [int]$max_parallel     = 8,
+    [int]$ssh_max_retries  = 3,
+    [int]$retry_sleep_secs = 120,
+    [string]$output_dir    = "C:\logs",
+    [switch]$no_skip,
+    [switch]$dry_run,
+    [switch]$force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ------------------ Skip list (consistent with other fleet scripts) ------------------
+$skip_nodes = @(
+    "nuc13-035","nuc13-036","nuc13-059","nuc13-060","nuc13-061",
+    "nuc13-068","nuc13-070","nuc13-075","nuc13-096","nuc13-112",
+    "nuc13-130","nuc13-149","nuc13-154","nuc13-155","nuc13-156","nuc13-157",
+    "nuc13-107","nuc13-150"
+)
+
+# ------------------ Resolve target list ------------------
+$target_shorts = @()
+if ($single) {
+    if (-not $node) { Write-Error "-node is required with -single"; exit 1 }
+    $target_shorts = @(($node -replace '\..*$', '').Trim())
+}
+elseif ($nodes) {
+    $target_shorts = @($nodes -split '[,\s]+' | Where-Object { $_ } | ForEach-Object { ($_ -replace '\..*$', '').Trim() })
+}
+else {
+    $target_shorts = $range_start..$range_end | ForEach-Object {
+        "{0}-{1:D$range_pad}" -f $range_prefix, $_
+    }
+}
+
+if (-not $no_skip -and -not $single) {
+    $hit = @($target_shorts | Where-Object { $skip_nodes -contains $_ })
+    $target_shorts = @($target_shorts | Where-Object { $skip_nodes -notcontains $_ })
+    if ($hit.Count -gt 0) {
+        Write-Host "Skipping $($hit.Count) known-problem node(s): $($hit -join ', ')" -ForegroundColor Yellow
+    }
+}
+
+if ($target_shorts.Count -eq 0) { Write-Error "No nodes to scan."; exit 1 }
+$targets = @($target_shorts | ForEach-Object { "$_.$domain_suffix" })
+
+# ------------------ Output paths ------------------
+$stamp   = (Get-Date).ToString('yyyyMMdd_HHmmss')
+if (-not (Test-Path $output_dir)) { New-Item -ItemType Directory $output_dir -Force | Out-Null }
+$logFile = Join-Path $output_dir ("uninstall_firefox_{0}nodes_{1}.log" -f $targets.Count, $stamp)
+$csvFile = Join-Path $output_dir ("uninstall_firefox_{0}nodes_{1}.csv" -f $targets.Count, $stamp)
+$jsonFile= Join-Path $output_dir ("uninstall_firefox_{0}nodes_{1}.json" -f $targets.Count, $stamp)
+Start-Transcript -Path $logFile -Append | Out-Null
+
+Write-Host ""
+Write-Host "------------------------------------------------------------"
+Write-Host "  UninstallFirefox fleet sweep"
+Write-Host "  Targets    : $($targets.Count)"
+Write-Host "  Parallel   : $max_parallel"
+Write-Host "  Retries    : up to $ssh_max_retries SSH retry passes"
+Write-Host "  Force      : $force"
+Write-Host "  Dry-run    : $dry_run"
+Write-Host "  CSV        : $csvFile"
+Write-Host "------------------------------------------------------------"
+Write-Host ""
+
+# ------------------ Remote diagnostic + uninstall payload ------------------
+$forceLiteral  = if ($force)  { '$true' } else { '$false' }
+$dryRunLiteral = if ($dry_run){ '$true' } else { '$false' }
+
+$diagPayload = @"
+`$ErrorActionPreference = 'Continue'
+`$forceUninstall = $forceLiteral
+`$dryRun         = $dryRunLiteral
+
+# --- Busy check (skip if generic-worker has a task) ---
+`$wsp = `$null
+foreach (`$p in @("C:\WINDOWS\SystemTemp", `$env:TMP, `$env:TEMP, `$env:USERPROFILE)) {
+    if (`$p) { `$c = Join-Path `$p "worker-status.json"; if (Test-Path `$c) { `$wsp = `$c; break } }
+}
+`$busy = `$false
+if (`$wsp) {
+    try { `$j = Get-Content `$wsp -Raw | ConvertFrom-Json; if (@(`$j.currentTaskIds).Count -gt 0) { `$busy = `$true } } catch {}
+}
+if (`$busy) {
+    [pscustomobject]@{ Status='busy'; Hostname=`$env:COMPUTERNAME } | ConvertTo-Json -Compress
+    return
+}
+
+# --- Pre-cleanup: kill any leftover firefox + StressSP3 scheduled tasks ---
+try { Get-Process firefox -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}
+try { Get-ScheduledTask -TaskName 'StressSP3_FF_*' -ErrorAction SilentlyContinue | Unregister-ScheduledTask -Confirm:`$false -ErrorAction SilentlyContinue } catch {}
+try { Remove-Item 'C:\Users\Public\sp3stress' -Recurse -Force -ErrorAction SilentlyContinue } catch {}
+Start-Sleep -Seconds 1
+
+# --- Detect Firefox install state ---
+`$ffPaths = @(
+    'C:\Program Files\Mozilla Firefox\firefox.exe',
+    'C:\Program Files (x86)\Mozilla Firefox\firefox.exe'
+)
+`$ffExeBefore = `$ffPaths | Where-Object { Test-Path `$_ } | Select-Object -First 1
+`$ffPresentBefore = `$null -ne `$ffExeBefore
+
+# --- Detect Chocolatey-managed status ---
+`$chocoExe = (Get-Command choco -ErrorAction SilentlyContinue).Source
+`$chocoOk  = `$null -ne `$chocoExe
+`$chocoListOut = ''
+`$chocoManaged = `$false
+if (`$chocoOk) {
+    try {
+        `$chocoListOut = (& choco list --local-only firefox -r 2>&1) -join "`n"
+        if (`$chocoListOut -match '(?im)^firefox\|') { `$chocoManaged = `$true }
+    } catch {}
+    if (-not `$chocoManaged) {
+        # older Choco versions: no -r, may print "Firefox v..." lines
+        try {
+            `$alt = (& choco list --local-only firefox 2>&1) -join "`n"
+            if (`$alt -match '(?im)^firefox\s+\S+') { `$chocoManaged = `$true; `$chocoListOut = `$alt }
+        } catch {}
+    }
+}
+
+# --- Decide whether to uninstall ---
+`$shouldUninstall = `$ffPresentBefore -and (`$chocoManaged -or `$forceUninstall)
+`$action = if (`$dryRun) { 'dry_run' } elseif (-not `$ffPresentBefore) { 'absent' } elseif (-not `$chocoManaged -and -not `$forceUninstall) { 'skipped_not_choco_managed' } elseif (-not `$chocoOk) { 'skipped_no_choco' } else { 'uninstalling' }
+
+`$chocoUninstallOut = ''
+`$chocoUninstallExit = `$null
+`$ffPresentAfter = `$ffPresentBefore
+if (`$shouldUninstall -and -not `$dryRun -and `$chocoOk) {
+    try {
+        `$chocoUninstallOut = (& choco uninstall firefox --yes --no-progress --limit-output --remove-dependencies 2>&1) -join "`n"
+        `$chocoUninstallExit = `$LASTEXITCODE
+    } catch {
+        `$chocoUninstallOut = `$_.Exception.Message
+    }
+    `$ffExeAfter = `$ffPaths | Where-Object { Test-Path `$_ } | Select-Object -First 1
+    `$ffPresentAfter = `$null -ne `$ffExeAfter
+    if (`$action -eq 'uninstalling') {
+        `$action = if (-not `$ffPresentAfter -and `$chocoUninstallExit -eq 0) { 'uninstalled' } else { 'uninstall_failed' }
+    }
+}
+
+[pscustomobject]@{
+    Status           = 'ok'
+    Hostname         = `$env:COMPUTERNAME
+    Timestamp        = (Get-Date).ToString('s')
+    FF_PresentBefore = `$ffPresentBefore
+    FF_PathBefore    = `$ffExeBefore
+    Choco_OK         = `$chocoOk
+    Choco_Managed    = `$chocoManaged
+    Choco_ListOut    = (`$chocoListOut -replace "`r`n",' ' | ForEach-Object { `$_.Substring(0,[math]::Min(400,`$_.Length)) })
+    Action           = `$action
+    Choco_Uninstall_Exit = `$chocoUninstallExit
+    Choco_Uninstall_Out  = (`$chocoUninstallOut -replace "`r`n",' ' | ForEach-Object { `$_.Substring(0,[math]::Min(400,`$_.Length)) })
+    FF_PresentAfter  = `$ffPresentAfter
+} | ConvertTo-Json -Depth 5 -Compress
+"@
+
+# ------------------ Per-node helper (scp + ssh -File) ------------------
+$rsScript = {
+    param(
+        [string]$Fqdn,
+        [string]$User,
+        [string]$Payload,
+        [System.Collections.Concurrent.ConcurrentQueue[string]]$MsgQueue
+    )
+
+    function Log { param([string]$Msg) $MsgQueue.Enqueue($Msg) }
+    $short = ($Fqdn -split '\.')[0]
+    Log "[$short] start"
+
+    $remoteName = "uninstall_firefox_$([guid]::NewGuid().ToString('N')).ps1"
+    $localTemp  = Join-Path $env:TEMP $remoteName
+    Set-Content -Path $localTemp -Value $Payload -Encoding UTF8
+
+    try {
+        $scpArgs = "-O -o ConnectTimeout=10 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no `"$localTemp`" `"${User}@${Fqdn}:$remoteName`""
+        $psi = [System.Diagnostics.ProcessStartInfo]::new('scp')
+        $psi.Arguments              = $scpArgs
+        $psi.UseShellExecute        = $false
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError  = $true
+        $psi.CreateNoWindow         = $true
+        $sp = [System.Diagnostics.Process]::Start($psi)
+        $sp.StandardOutput.ReadToEnd() | Out-Null
+        $scpErr = $sp.StandardError.ReadToEnd()
+        $exited = $sp.WaitForExit(25000)
+        if (-not $exited) { try { $sp.Kill() } catch {}; return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="scp timeout" } }
+        $scpExit = $sp.ExitCode
+        $sp.Dispose()
+        if ($scpExit -ne 0) {
+            return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="scp exit $scpExit : $scpErr" }
+        }
+
+        Log "[$short] running uninstall"
+        # Absolute home path so the same command works whether the SSH default shell is PowerShell or cmd.exe
+        $remoteCmd = "powershell -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File C:\Users\Administrator\$remoteName"
+        $sshArgs = "-o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=4 -o UserKnownHostsFile=NUL -o StrictHostKeyChecking=no ${User}@${Fqdn} $remoteCmd"
+        $psi2 = [System.Diagnostics.ProcessStartInfo]::new('ssh')
+        $psi2.Arguments              = $sshArgs
+        $psi2.UseShellExecute        = $false
+        $psi2.RedirectStandardOutput = $true
+        $psi2.RedirectStandardError  = $true
+        $psi2.CreateNoWindow         = $true
+        $sp2 = [System.Diagnostics.Process]::Start($psi2)
+        $stdout = $sp2.StandardOutput.ReadToEnd()
+        $stderr = $sp2.StandardError.ReadToEnd()
+        # choco uninstall can take 60-180s; allow up to 5 min
+        $exited2 = $sp2.WaitForExit(300000)
+        if (-not $exited2) { try { $sp2.Kill() } catch {}; return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="ssh timeout" } }
+        $sshExit = $sp2.ExitCode
+        $sp2.Dispose()
+        if ($sshExit -ne 0) {
+            return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="ssh exit $sshExit : $stderr" }
+        }
+
+        $jsonLine = ($stdout -split "`n") | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        if (-not $jsonLine) {
+            return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="no JSON in stdout" }
+        }
+        try {
+            $obj = $jsonLine | ConvertFrom-Json
+        } catch {
+            return [pscustomobject]@{ _s='ssherr'; Fqdn=$Fqdn; Reason="JSON parse: $_" }
+        }
+        if ($obj.Status -eq 'busy') {
+            return [pscustomobject]@{ _s='busy'; Fqdn=$Fqdn; Hostname=$obj.Hostname }
+        }
+        return [pscustomobject]@{ _s='ok'; Fqdn=$Fqdn; Data=$obj }
+    } finally {
+        Remove-Item $localTemp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ------------------ Parallel batch runner ------------------
+function Invoke-ScanBatch {
+    param([string[]]$Fqdns, [int]$Parallel)
+
+    $rsPool = [RunspaceFactory]::CreateRunspacePool(1, [math]::Max(1, $Parallel))
+    $rsPool.Open()
+    $msgQueue = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
+    function Drain-Queue {
+        $msg = $null
+        while ($msgQueue.TryDequeue([ref]$msg)) { Write-Host $msg; $msg = $null }
+    }
+
+    $totalBatches = [math]::Ceiling($Fqdns.Count / $Parallel)
+    $batchNum = 0
+    $batchResults = @{}
+
+    for ($i = 0; $i -lt $Fqdns.Count; $i += $Parallel) {
+        $batchNum++
+        $batch = $Fqdns[$i..[math]::Min($i + $Parallel - 1, $Fqdns.Count - 1)]
+        Write-Host ("  Batch {0}/{1} : {2} node(s)" -f $batchNum, $totalBatches, $batch.Count)
+        $jobs = [System.Collections.Generic.List[object]]::new()
+        foreach ($fqdn in $batch) {
+            $ps = [PowerShell]::Create()
+            $ps.RunspacePool = $rsPool
+            [void]$ps.AddScript($rsScript)
+            [void]$ps.AddParameters(@{ Fqdn=$fqdn; User=$ssh_user; Payload=$diagPayload; MsgQueue=$msgQueue })
+            $jobs.Add([pscustomobject]@{ PS=$ps; Handle=$ps.BeginInvoke(); Fqdn=$fqdn })
+        }
+        $pending = [System.Collections.Generic.List[object]]::new($jobs)
+        $lastHB = [datetime]::Now
+        while ($pending.Count -gt 0) {
+            Drain-Queue
+            if (([datetime]::Now - $lastHB).TotalSeconds -ge 30) {
+                Write-Host ("    [waiting] {0} node(s) still in this batch..." -f $pending.Count)
+                $lastHB = [datetime]::Now
+            }
+            $done = @($pending | Where-Object { $_.Handle.IsCompleted })
+            foreach ($job in $done) {
+                [void]$pending.Remove($job)
+                try { $r = $job.PS.EndInvoke($job.Handle)[0] }
+                catch { $r = [pscustomobject]@{ _s='ssherr'; Fqdn=$job.Fqdn; Reason="runspace error: $_" } }
+                $job.PS.Dispose()
+                $batchResults[$job.Fqdn] = $r
+                $short = ($job.Fqdn -split '\.')[0]
+                $msg = switch ($r._s) {
+                    'ok'     { "[$short] $($r.Data.Action)  before=$($r.Data.FF_PresentBefore)  managed=$($r.Data.Choco_Managed)  after=$($r.Data.FF_PresentAfter)" }
+                    'busy'   { "[$short] busy (skipped)" }
+                    'ssherr' { "[$short] SSH/diag failed: $($r.Reason)" }
+                    default  { "[$short] unknown state" }
+                }
+                Write-Host $msg
+            }
+            if ($pending.Count -gt 0) { Start-Sleep -Milliseconds 250 }
+        }
+        Drain-Queue
+    }
+    $rsPool.Close()
+    $rsPool.Dispose()
+    return $batchResults
+}
+
+# ------------------ PASS 1 ------------------
+Write-Host ""
+Write-Host "==== PASS 1 ===="
+$results = @{}
+$pass1 = Invoke-ScanBatch -Fqdns $targets -Parallel $max_parallel
+foreach ($k in $pass1.Keys) { $results[$k] = $pass1[$k] }
+
+# ------------------ Busy retry pass ------------------
+$busyPass = 0
+while (-not $dry_run -and ($results.GetEnumerator() | Where-Object { $_.Value._s -eq 'busy' } | Measure-Object).Count -gt 0) {
+    $busyPass++
+    if ($busyPass -gt 3) { Write-Host "Busy retry cap (3) hit; remaining busy nodes will be reported as such."; break }
+    $busyTargets = @($results.GetEnumerator() | Where-Object { $_.Value._s -eq 'busy' } | ForEach-Object { $_.Key })
+    Write-Host ""
+    Write-Host ("---- Sleeping {0}s : busy retry {1} - {2} node(s) ----" -f $retry_sleep_secs, $busyPass, $busyTargets.Count)
+    Start-Sleep -Seconds $retry_sleep_secs
+    $r = Invoke-ScanBatch -Fqdns $busyTargets -Parallel $max_parallel
+    foreach ($k in $r.Keys) { $results[$k] = $r[$k] }
+}
+
+# ------------------ SSH retry passes ------------------
+$pass = 1
+while ($pass -le $ssh_max_retries) {
+    $failed = @($results.GetEnumerator() | Where-Object { $_.Value._s -eq 'ssherr' } | ForEach-Object { $_.Key })
+    if ($failed.Count -eq 0) { break }
+    Write-Host ""
+    Write-Host ("---- Sleeping {0}s : SSH retry {1} of {2} - {3} node(s) ----" -f $retry_sleep_secs, $pass, $ssh_max_retries, $failed.Count)
+    Start-Sleep -Seconds $retry_sleep_secs
+    Write-Host ("==== RETRY PASS {0} ({1} node(s)) ====" -f $pass, $failed.Count)
+    $r = Invoke-ScanBatch -Fqdns $failed -Parallel $max_parallel
+    foreach ($k in $r.Keys) { $results[$k] = $r[$k] }
+    $pass++
+}
+
+# ------------------ Build CSV rows ------------------
+$rows = foreach ($fqdn in $targets) {
+    $short = ($fqdn -split '\.')[0]
+    $r = if ($results.ContainsKey($fqdn)) { $results[$fqdn] } else { [pscustomobject]@{ _s='ssherr'; Reason='not attempted' } }
+    if ($r._s -eq 'ok' -and $r.Data) {
+        $d = $r.Data
+        [pscustomobject]@{
+            Hostname           = $short
+            Status             = 'ok'
+            Action             = $d.Action
+            FF_PresentBefore   = $d.FF_PresentBefore
+            FF_PathBefore      = $d.FF_PathBefore
+            Choco_Managed      = $d.Choco_Managed
+            Choco_OK           = $d.Choco_OK
+            Choco_ListOut      = $d.Choco_ListOut
+            Choco_Uninstall_Exit = $d.Choco_Uninstall_Exit
+            Choco_Uninstall_Out  = $d.Choco_Uninstall_Out
+            FF_PresentAfter    = $d.FF_PresentAfter
+            Timestamp          = $d.Timestamp
+        }
+    } elseif ($r._s -eq 'busy') {
+        [pscustomobject]@{ Hostname=$short; Status='busy'; Action='busy_skipped'; FF_PresentBefore=''; FF_PathBefore=''; Choco_Managed=''; Choco_OK=''; Choco_ListOut=''; Choco_Uninstall_Exit=''; Choco_Uninstall_Out=''; FF_PresentAfter=''; Timestamp='' }
+    } else {
+        $reason = if ($r.PSObject.Properties.Name -contains 'Reason') { ($r.Reason -replace "`r`n",' ' -replace "\s+", ' ') } else { 'unknown' }
+        [pscustomobject]@{ Hostname=$short; Status='ssh_failed'; Action='ssh_failed'; FF_PresentBefore=''; FF_PathBefore=''; Choco_Managed=''; Choco_OK=''; Choco_ListOut=$reason; Choco_Uninstall_Exit=''; Choco_Uninstall_Out=''; FF_PresentAfter=''; Timestamp='' }
+    }
+}
+
+$rows | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+$results | ConvertTo-Json -Depth 6 | Set-Content -Path $jsonFile -Encoding UTF8
+
+# ------------------ Summary ------------------
+$ok      = @($rows | Where-Object { $_.Status -eq 'ok' })
+$busy    = @($rows | Where-Object { $_.Status -eq 'busy' })
+$failed  = @($rows | Where-Object { $_.Status -eq 'ssh_failed' })
+
+Write-Host ""
+Write-Host "============================================================"
+Write-Host "  SUMMARY"
+Write-Host "============================================================"
+Write-Host ("  Scanned         : {0}" -f $rows.Count)
+Write-Host ("  Reached         : {0}" -f $ok.Count)
+Write-Host ("  Busy (skipped)  : {0}" -f $busy.Count)
+Write-Host ("  SSH failed      : {0}  (after $ssh_max_retries retries)" -f $failed.Count)
+Write-Host ""
+
+if ($ok.Count -gt 0) {
+    $byAction = $ok | Group-Object Action | Sort-Object Count -Descending
+    Write-Host "==== Actions on reached nodes ===="
+    foreach ($g in $byAction) {
+        Write-Host ("  {0,-30} : {1}" -f $g.Name, $g.Count)
+    }
+    Write-Host ""
+
+    $stillPresent = @($ok | Where-Object { $_.FF_PresentAfter -eq $true -and $_.FF_PresentBefore -eq $true })
+    if ($stillPresent.Count -gt 0) {
+        Write-Host "==== Nodes where Firefox is still present after this run ===="
+        foreach ($r in $stillPresent) {
+            Write-Host ("  {0}  action={1}  managed={2}  exit={3}" -f $r.Hostname, $r.Action, $r.Choco_Managed, $r.Choco_Uninstall_Exit)
+        }
+        Write-Host ""
+    }
+
+    $absent = @($ok | Where-Object { $_.FF_PresentBefore -eq $false })
+    Write-Host ("Nodes that already had no Firefox: {0}" -f $absent.Count)
+    Write-Host ""
+}
+
+if ($busy.Count -gt 0) {
+    Write-Host "==== BUSY (skipped) ===="
+    $busy | ForEach-Object { Write-Host ("  {0}" -f $_.Hostname) }
+}
+if ($failed.Count -gt 0) {
+    Write-Host ""
+    Write-Host "==== FAILED (after retries) ===="
+    $failed | ForEach-Object { Write-Host ("  {0}  -- {1}" -f $_.Hostname, $_.Choco_ListOut) }
+}
+
+Write-Host ""
+Write-Host "Log : $logFile"
+Write-Host "CSV : $csvFile"
+Write-Host "JSON: $jsonFile"
+Stop-Transcript | Out-Null


### PR DESCRIPTION
## Summary

Tracks the SSH-based PowerShell stress-test toolkit developed during the [RELOPS-2323](https://mozilla-hub.atlassian.net/browse/RELOPS-2323) throttling/perf-degrade investigation. The 5-loop fleet sweep these scripts produced is what informed the win11-64-24h2-hw pool realignment in #774.

Adds 7 scripts + 1 README under `provisioners/windows/MDC1Windows/utility_scripts/stress_test/`:

| Script | Purpose |
| --- | --- |
| `StressSP3.ps1` | SP3 + Marionette + ETW workload per node (the flagship) |
| `StressSP3-Fleet.ps1` | Fleet-wide wrapper around StressSP3 (range/list/single) |
| `StressCPU.ps1` | prime95 torture-mode CPU stress (older heavy test) |
| `Scan-NUCHealth.ps1` | Fast ~10-min triage burner (`% Processor Performance` sampling) |
| `Compare-NUCHealth.ps1` | Side-by-side hardware/firmware diff across a small node set |
| `CleanupSP3.ps1` | Per-node reset for aborted StressSP3 runs |
| `UninstallFirefox.ps1` | Fleet-wide cleanup of choco-managed Firefox installs |

Scripts are the latest revisions from [RELOPS-2323 comment 1420888](https://mozilla-hub.atlassian.net/browse/RELOPS-2323?focusedCommentId=1420888) attachments (uploaded 2026-05-08). No code modifications - imported as-is so the repo history matches the Jira-attached versions.

## Why

These were living as ticket attachments. Moving them into the repo so:

- They're versioned and reviewable alongside the worker config they characterize
- `pools.yml` realignments driven by their data (e.g. #774) can be traced back to the exact script revision that produced the numbers
- Future cadence runs (per the RELOPS-2323 analysis: Scan-NUCHealth daily, `StressSP3-Fleet -sp3_loops 3` monthly) have a canonical home and don't have to re-fetch ticket attachments

## What's in the README

`stress_test/README.md` covers:

- The shared SSH+scp transport pattern (and why scp+`-File` over `-EncodedCommand` - cmd.exe 8191-char limit)
- The parallelism model (RunspacePool, not Start-Job, for cold-cache startup cost)
- The "busy gate" that prevents disturbing live CI tasks
- A per-script breakdown with the key fields each one captures
- Recommended fleet-cadence (Scan daily, SP3 3-loop monthly, SP3 5-loop for thermal-degrade hunts)
- Output filename conventions

## Known outstanding issues (not addressed in this PR)

Flagging these so they're visible but leaving them out of scope - this PR imports the scripts as-is from the ticket:

1. **cmd-shell SSH bug in `StressSP3.ps1`** (lines 155 + 935): trailing `; Remove-Item ...` gets concatenated into the `-File` path arg when the remote default shell is cmd.exe. Affects nuc13-124, -132, -152. The fix is already in `Scan-NUCHealth.ps1` (line 245) - needs porting.
2. **Skip-list drift**: `StressCPU.ps1` includes `nuc13-024` in its skip list; `Scan-NUCHealth`/`StressSP3-Fleet`/`UninstallFirefox` do not. The Jira comment confirms 024 is unreachable - should be in all skip lists. Worth lifting to a shared source (or reading `pools.yml`'s `Known-BAD` block).
3. **`StressSP3.ps1` has a hardcoded 20-node default target list** (lines 67-72). Anyone running `.\StressSP3.ps1` without `-nodes` hits that specific list. `StressSP3-Fleet.ps1` always passes `-nodes` explicitly so fleet sweeps are unaffected; only interactive invocations are surprising.
4. **`Scan-NUCHealth.ps1` leaves `scan_nuchealth_*.ps1` files in `C:\Users\Administrator\\`** (deliberate trade-off documented in the script - the trailing `; Remove-Item` would trigger the cmd-shell bug). `CleanupSP3.ps1` only cleans `stress_payload_*.ps1` today.

I can open a follow-up PR for any of these - they're separate work from importing.

## Test plan

- [ ] `stress_test/` directory and 8 files (7 scripts + README) land under `provisioners/windows/MDC1Windows/utility_scripts/`
- [ ] No existing files modified
- [ ] PowerShell ScriptAnalyzer (`PSScriptAnalyzerSettings.psd1` at repo root) doesn't fire on these (or any warnings are scoped to known-acceptable patterns - imports preserve the original style intentionally)
- [ ] Spot-check one script (e.g. `Scan-NUCHealth.ps1 -dry_run -range_end 5`) runs to completion locally with no syntax errors