### PR TITLE
Bug 1941642 - Run os-integration tests on Linux alpha images

### DIFF
--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      os_integration_matrix: ${{ steps.set-matrix.outputs.os_integration_matrix }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -35,6 +36,14 @@ jobs:
           $matrix = @{ config = @($configs) } | ConvertTo-Json -Compress
           Write-Host "Generated matrix: $matrix"
           "matrix=$matrix" >> $env:GITHUB_OUTPUT
+
+          # Only level-1 (untrusted) alpha configs have matching alpha worker pools
+          # in fxci-config that the os-integration cron can target. Skip trusted-
+          # (level-3) configs.
+          $osIntConfigs = $configs | Where-Object { $_ -notmatch '^trusted-' }
+          $osIntMatrix = @{ config = @($osIntConfigs) } | ConvertTo-Json -Compress
+          Write-Host "Generated os-integration matrix: $osIntMatrix"
+          "os_integration_matrix=$osIntMatrix" >> $env:GITHUB_OUTPUT
 
   check-access:
     name: Verify User Access
@@ -118,3 +127,16 @@ jobs:
         env:
           WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
+
+  os-integration:
+    needs: [prepare-matrix, packer]
+    name: "OS Integration Tests - ${{ matrix.config }}"
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.os_integration_matrix) }}
+    uses: ./.github/workflows/os-integration.yml
+    with:
+      config: ${{ matrix.config }}
+    secrets:
+      TASKCLUSTER_OS_INT_CLIENT_ID: ${{ secrets.TASKCLUSTER_OS_INT_CLIENT_ID }}
+      TASKCLUSTER_OS_INT_ACCESS_TOKEN: ${{ secrets.TASKCLUSTER_OS_INT_ACCESS_TOKEN }}

--- a/.github/workflows/os-integration.yml
+++ b/.github/workflows/os-integration.yml
@@ -17,6 +17,9 @@ on:
         - win11-a64-24h2-builder-alpha
         - win11-a64-25h2-builder-alpha
         - win2022-64-2009-alpha
+        - gw-fxci-gcp-l1-2404-gui-alpha
+        - gw-fxci-gcp-l1-2404-headless-alpha
+        - gw-fxci-gcp-l1-2404-arm64-headless-alpha
       image_name:
         type: string
         description: Optional shared image name override
@@ -70,11 +73,17 @@ jobs:
             Set-PSRepository PSGallery -InstallationPolicy Trusted
             Install-Module powershell-yaml -ErrorAction Stop
             $yaml = ConvertFrom-Yaml (Get-Content "config/$($env:CONFIG).yaml" -Raw)
-            $imageName = $yaml.sharedimage.image_name
+            # Windows configs use sharedimage.image_name (Azure Shared Image Gallery name).
+            # Linux GCP configs use image.image_name (GCP image name).
+            if ($yaml.sharedimage.image_name) {
+              $imageName = $yaml.sharedimage.image_name
+            } else {
+              $imageName = $yaml.image.image_name
+            }
           }
 
           if (-not $imageName) {
-            Write-Host "::error ::Unable to determine shared image name"
+            Write-Host "::error ::Unable to determine image name from config/$($env:CONFIG).yaml"
             exit 1
           }
 

--- a/taskcluster/kinds/integration-test/kind.yml
+++ b/taskcluster/kinds/integration-test/kind.yml
@@ -21,6 +21,7 @@ tasks:
           - test
           - mochitest
           - browsertime
+          - snap-upstream-test
           - web-platform-tests
       exclude-attrs:
         test_platform:


### PR DESCRIPTION
## Summary

Wires up Linux GCP alpha image builds to trigger os-integration tests automatically, mirroring the Windows alpha-parallel workflow.

- `taskcluster/kinds/integration-test/kind.yml`: include `snap-upstream-test` so the gecko snap tests added to `os-integration` in autoland `0ef817f332d2` get mirrored onto the new `gecko-t/t-linux-2404-wayland-snap-alpha` pool (mozilla-releng/fxci-config#998).
- `.github/workflows/os-integration.yml`: fall back to `image.image_name` when `sharedimage.image_name` is absent so the resolve step works for the GCP config schema. Adds the three level-1 GCP alpha configs to the manual `workflow_dispatch` dropdown.
- `.github/workflows/gcp-fxci-parallel-alpha.yml`: `prepare-matrix` now emits `os_integration_matrix` (filtered to level-1 configs; trusted/l3 don't have matching alpha pools), and an `os-integration` job calls the shared workflow after `packer` completes — same shape as `sig-FXCI-nontrusted-parallel-build-alpha.yml`.

## Verification

Local dry-run with `TASK_ID=fake taskgraph full -p taskcluster/test/params/cron-run-integration-tests.yml` shows the new snap task routes correctly:

```
gecko-snap-upstream-test-basic-2404-amd64-nightly/opt
  workerType: t-linux-2404-wayland-snap-alpha
  provisionerId: gecko-t
```

## Test plan

- [ ] Re-run `gcp-fxci-parallel-alpha.yml` and confirm the new `os-integration` matrix jobs run after packer.
- [ ] Confirm `gw-fxci-gcp-l1-2404-gui-alpha` triggers the snap test on `gecko-t/t-linux-2404-wayland-snap-alpha`.
- [ ] Spot-check that the other two configs (headless + arm64-headless) trigger their respective alpha pools.