### PR TITLE
Run os-integration after packer, independent of wiz/SBOM

### DIFF
--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -103,21 +103,58 @@ jobs:
           }
           New-GCPWorkerImage @Vars
 
-  wiz-scan:
+  find-successful-builds:
     needs: [prepare-matrix, packer]
-    name: "Wiz Scan - ${{ matrix.config }}"
+    name: "Filter matrices to successful packer builds"
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
+    outputs:
+      wiz_matrix: ${{ steps.filter.outputs.wiz_matrix }}
+      os_integration_matrix: ${{ steps.filter.outputs.os_integration_matrix }}
+    steps:
+      - id: filter
+        name: Query run jobs API for successful packer entries
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORIGINAL_OS_INT_MATRIX: ${{ needs.prepare-matrix.outputs.os_integration_matrix }}
+        run: |
+          $allJobs = gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" --paginate | ConvertFrom-Json
+          $successful = @()
+          foreach ($job in $allJobs.jobs) {
+            if ($job.name -match '^Build (.+)$' -and $job.conclusion -eq 'success') {
+              $successful += $matches[1]
+            }
+          }
+          Write-Host "Successful packer configs: $($successful -join ', ')"
+
+          # Wiz runs against every successful non-trusted build.
+          $wizConfigs = $successful | Where-Object { $_ -notmatch '^trusted-' }
+          $wizMatrix = @{ config = @($wizConfigs) } | ConvertTo-Json -Compress
+          Write-Host "wiz_matrix=$wizMatrix"
+          "wiz_matrix=$wizMatrix" >> $env:GITHUB_OUTPUT
+
+          # os-integration runs against configs that were both in the original
+          # os_integration_matrix (level-1) AND succeeded in packer.
+          $original = ConvertFrom-Json $env:ORIGINAL_OS_INT_MATRIX
+          $osIntConfigs = $original.config | Where-Object { $successful -contains $_ }
+          $osIntMatrix = @{ config = @($osIntConfigs) } | ConvertTo-Json -Compress
+          Write-Host "os_integration_matrix=$osIntMatrix"
+          "os_integration_matrix=$osIntMatrix" >> $env:GITHUB_OUTPUT
+
+  wiz-scan:
+    needs: [find-successful-builds]
+    if: ${{ fromJson(needs.find-successful-builds.outputs.wiz_matrix).config[0] != null }}
+    name: "Wiz Scan - ${{ matrix.config }}"
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.find-successful-builds.outputs.wiz_matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        if: ${{ !contains(matrix.config, 'trusted') }}
 
       - id: set-gcp-vars
         name: Set project and image metadata
-        if: ${{ !contains(matrix.config, 'trusted') }}
         shell: pwsh
         run: |
           Import-Module ${{ github.workspace }}\bin\WorkerImages\WorkerImages.psm1
@@ -125,18 +162,15 @@ jobs:
           Set-GCPWorkerImageProject -Key '${{ matrix.config }}'
 
       - name: Download Wiz CLI
-        if: ${{ !contains(matrix.config, 'trusted') }}
         run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
       - name: Authenticate to Wiz
-        if: ${{ !contains(matrix.config, 'trusted') }}
         run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
         env:
           WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
 
       - name: Run wiz-cli scan
-        if: ${{ !contains(matrix.config, 'trusted') }}
         run: |
           ./wizcli vm-image scan \
           --id ${{ steps.set-gcp-vars.outputs.IMAGENAME }} \
@@ -150,12 +184,12 @@ jobs:
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
 
   os-integration:
-    needs: [prepare-matrix, packer]
-    if: ${{ !cancelled() }}
+    needs: [find-successful-builds]
+    if: ${{ fromJson(needs.find-successful-builds.outputs.os_integration_matrix).config[0] != null }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-matrix.outputs.os_integration_matrix) }}
+      matrix: ${{ fromJson(needs.find-successful-builds.outputs.os_integration_matrix) }}
     uses: ./.github/workflows/os-integration.yml
     with:
       config: ${{ matrix.config }}

--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -108,6 +108,8 @@ jobs:
     name: "Filter matrices to successful packer builds"
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
+    permissions:
+      actions: read
     outputs:
       wiz_matrix: ${{ steps.filter.outputs.wiz_matrix }}
       os_integration_matrix: ${{ steps.filter.outputs.os_integration_matrix }}

--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -103,19 +103,40 @@ jobs:
           }
           New-GCPWorkerImage @Vars
 
+  wiz-scan:
+    needs: [prepare-matrix, packer]
+    name: "Wiz Scan - ${{ matrix.config }}"
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        if: ${{ !contains(matrix.config, 'trusted') }}
+
+      - id: set-gcp-vars
+        name: Set project and image metadata
+        if: ${{ !contains(matrix.config, 'trusted') }}
+        shell: pwsh
+        run: |
+          Import-Module ${{ github.workspace }}\bin\WorkerImages\WorkerImages.psm1
+          Set-GCPWorkerImageName -Key '${{ matrix.config }}'
+          Set-GCPWorkerImageProject -Key '${{ matrix.config }}'
+
       - name: Download Wiz CLI
-        if: ${{ success() && !contains(matrix.config, 'trusted') }}
+        if: ${{ !contains(matrix.config, 'trusted') }}
         run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
       - name: Authenticate to Wiz
-        if: ${{ success() && !contains(matrix.config, 'trusted') }}
+        if: ${{ !contains(matrix.config, 'trusted') }}
         run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
         env:
           WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
 
       - name: Run wiz-cli scan
-        if: ${{ success() && !contains(matrix.config, 'trusted') }}
+        if: ${{ !contains(matrix.config, 'trusted') }}
         run: |
           ./wizcli vm-image scan \
           --id ${{ steps.set-gcp-vars.outputs.IMAGENAME }} \
@@ -130,6 +151,7 @@ jobs:
 
   os-integration:
     needs: [prepare-matrix, packer]
+    if: ${{ !cancelled() }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
+++ b/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
@@ -142,13 +142,43 @@ jobs:
           commit_message: "Update release notes"
           file_pattern: "sboms/*.md"
 
-  os-integration:
+  find-successful-builds:
     needs: [prepare-matrix, packer]
+    name: "Filter os-integration matrix to successful packer builds"
+    runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
+    outputs:
+      os_integration_matrix: ${{ steps.filter.outputs.os_integration_matrix }}
+    steps:
+      - id: filter
+        name: Query run jobs API for successful packer entries
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORIGINAL_OS_INT_MATRIX: ${{ needs.prepare-matrix.outputs.os_integration_matrix }}
+        run: |
+          $allJobs = gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" --paginate | ConvertFrom-Json
+          $successful = @()
+          foreach ($job in $allJobs.jobs) {
+            if ($job.name -match '^Build (.+)$' -and $job.conclusion -eq 'success') {
+              $successful += $matches[1]
+            }
+          }
+          Write-Host "Successful packer configs: $($successful -join ', ')"
+
+          $original = ConvertFrom-Json $env:ORIGINAL_OS_INT_MATRIX
+          $osIntConfigs = $original.config | Where-Object { $successful -contains $_ }
+          $osIntMatrix = @{ config = @($osIntConfigs) } | ConvertTo-Json -Compress
+          Write-Host "os_integration_matrix=$osIntMatrix"
+          "os_integration_matrix=$osIntMatrix" >> $env:GITHUB_OUTPUT
+
+  os-integration:
+    needs: [find-successful-builds]
+    if: ${{ fromJson(needs.find-successful-builds.outputs.os_integration_matrix).config[0] != null }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-matrix.outputs.os_integration_matrix) }}
+      matrix: ${{ fromJson(needs.find-successful-builds.outputs.os_integration_matrix) }}
     uses: ./.github/workflows/os-integration.yml
     with:
       config: ${{ matrix.config }}

--- a/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
+++ b/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
@@ -147,6 +147,8 @@ jobs:
     name: "Filter os-integration matrix to successful packer builds"
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
+    permissions:
+      actions: read
     outputs:
       os_integration_matrix: ${{ steps.filter.outputs.os_integration_matrix }}
     steps:

--- a/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
+++ b/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
@@ -144,6 +144,7 @@ jobs:
 
   os-integration:
     needs: [prepare-matrix, packer]
+    if: ${{ !cancelled() }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Follow-up to #776, based on a real run that surfaced two gaps:

- **Wiz scan blocked os-integration.** Wiz was a step inside the `packer` job, so `os-integration` (with `needs: [packer]`) had to wait for both the build *and* the scan. Split `wiz-scan` into its own job in `gcp-fxci-parallel-alpha.yml`.
- **A failed packer config skipped the entire os-integration matrix.** A transient GCP STOCKOUT on `trusted-gw-fxci-gcp-l3-2404-arm64-headless-alpha` flipped the overall `packer` job to `failure` and GitHub Actions skipped the downstream `os-integration` job — including for the level-1 configs that built fine.

## Design — per-config matrix filtering

A new `find-successful-builds` job runs after `packer` with `if: !cancelled()` and queries the run's Jobs API to find which `packer` matrix entries succeeded. It emits filtered matrices that `wiz-scan` and `os-integration` consume.

Result: each downstream job runs only for configs whose build actually succeeded, in parallel with each other.

Same pattern applied to `sig-FXCI-nontrusted-parallel-build-alpha.yml` for its `os-integration` job (no wiz on the Windows side; SBOM is already independent via `if: always()`).

## Test plan

- [ ] Re-run `gcp-fxci-parallel-alpha.yml`. Confirm `wiz-scan` and `os-integration` start in parallel for the level-1 configs that succeeded.
- [ ] Force one packer matrix entry to fail and confirm `wiz-scan` and `os-integration` are *not* scheduled for that config but still run for the others.