### PR TITLE
Use explicit boolean output to gate filtered matrix jobs

### DIFF
--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -113,6 +113,8 @@ jobs:
     outputs:
       wiz_matrix: ${{ steps.filter.outputs.wiz_matrix }}
       os_integration_matrix: ${{ steps.filter.outputs.os_integration_matrix }}
+      has_wiz_targets: ${{ steps.filter.outputs.has_wiz_targets }}
+      has_os_integration_targets: ${{ steps.filter.outputs.has_os_integration_targets }}
     steps:
       - id: filter
         name: Query run jobs API for successful packer entries
@@ -131,22 +133,26 @@ jobs:
           Write-Host "Successful packer configs: $($successful -join ', ')"
 
           # Wiz runs against every successful non-trusted build.
-          $wizConfigs = $successful | Where-Object { $_ -notmatch '^trusted-' }
-          $wizMatrix = @{ config = @($wizConfigs) } | ConvertTo-Json -Compress
+          $wizConfigs = @($successful | Where-Object { $_ -notmatch '^trusted-' })
+          $wizMatrix = @{ config = $wizConfigs } | ConvertTo-Json -Compress
           Write-Host "wiz_matrix=$wizMatrix"
           "wiz_matrix=$wizMatrix" >> $env:GITHUB_OUTPUT
+          $hasWiz = if ($wizConfigs.Count -gt 0) { 'true' } else { 'false' }
+          "has_wiz_targets=$hasWiz" >> $env:GITHUB_OUTPUT
 
           # os-integration runs against configs that were both in the original
           # os_integration_matrix (level-1) AND succeeded in packer.
           $original = ConvertFrom-Json $env:ORIGINAL_OS_INT_MATRIX
-          $osIntConfigs = $original.config | Where-Object { $successful -contains $_ }
-          $osIntMatrix = @{ config = @($osIntConfigs) } | ConvertTo-Json -Compress
+          $osIntConfigs = @($original.config | Where-Object { $successful -contains $_ })
+          $osIntMatrix = @{ config = $osIntConfigs } | ConvertTo-Json -Compress
           Write-Host "os_integration_matrix=$osIntMatrix"
           "os_integration_matrix=$osIntMatrix" >> $env:GITHUB_OUTPUT
+          $hasOsInt = if ($osIntConfigs.Count -gt 0) { 'true' } else { 'false' }
+          "has_os_integration_targets=$hasOsInt" >> $env:GITHUB_OUTPUT
 
   wiz-scan:
     needs: [find-successful-builds]
-    if: ${{ fromJson(needs.find-successful-builds.outputs.wiz_matrix).config[0] != null }}
+    if: ${{ needs.find-successful-builds.outputs.has_wiz_targets == 'true' }}
     name: "Wiz Scan - ${{ matrix.config }}"
     runs-on: ubuntu-latest
     strategy:
@@ -187,7 +193,7 @@ jobs:
 
   os-integration:
     needs: [find-successful-builds]
-    if: ${{ fromJson(needs.find-successful-builds.outputs.os_integration_matrix).config[0] != null }}
+    if: ${{ needs.find-successful-builds.outputs.has_os_integration_targets == 'true' }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
+++ b/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
@@ -151,6 +151,7 @@ jobs:
       actions: read
     outputs:
       os_integration_matrix: ${{ steps.filter.outputs.os_integration_matrix }}
+      has_os_integration_targets: ${{ steps.filter.outputs.has_os_integration_targets }}
     steps:
       - id: filter
         name: Query run jobs API for successful packer entries
@@ -169,14 +170,16 @@ jobs:
           Write-Host "Successful packer configs: $($successful -join ', ')"
 
           $original = ConvertFrom-Json $env:ORIGINAL_OS_INT_MATRIX
-          $osIntConfigs = $original.config | Where-Object { $successful -contains $_ }
-          $osIntMatrix = @{ config = @($osIntConfigs) } | ConvertTo-Json -Compress
+          $osIntConfigs = @($original.config | Where-Object { $successful -contains $_ })
+          $osIntMatrix = @{ config = $osIntConfigs } | ConvertTo-Json -Compress
           Write-Host "os_integration_matrix=$osIntMatrix"
           "os_integration_matrix=$osIntMatrix" >> $env:GITHUB_OUTPUT
+          $hasOsInt = if ($osIntConfigs.Count -gt 0) { 'true' } else { 'false' }
+          "has_os_integration_targets=$hasOsInt" >> $env:GITHUB_OUTPUT
 
   os-integration:
     needs: [find-successful-builds]
-    if: ${{ fromJson(needs.find-successful-builds.outputs.os_integration_matrix).config[0] != null }}
+    if: ${{ needs.find-successful-builds.outputs.has_os_integration_targets == 'true' }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

The previous run on commit \`efe1ffe2\` ([run 25926347902](https://github.com/mozilla-platform-ops/worker-images/actions/runs/25926347902)) showed the new filter design working *correctly* — \`find-successful-builds\` ran with \`actions: read\`, queried the Jobs API, and emitted populated matrices:

\`\`\`
Successful packer configs: gw-fxci-gcp-l1-2404-gui-alpha, trusted-gw-fxci-gcp-l3-2404-headless-alpha, gw-fxci-gcp-l1-2404-headless-alpha
wiz_matrix={"config":["gw-fxci-gcp-l1-2404-gui-alpha","gw-fxci-gcp-l1-2404-headless-alpha"]}
os_integration_matrix={"config":["gw-fxci-gcp-l1-2404-gui-alpha","gw-fxci-gcp-l1-2404-headless-alpha"]}
\`\`\`

…but the downstream \`wiz-scan\` and \`os-integration\` jobs were nonetheless **skipped**. The unexpanded \`\${{ matrix.config }}\` in the skipped job names confirms the job-level \`if:\` blocked matrix expansion entirely.

The \`if: \${{ fromJson(...).config[0] != null }}\` form is unreliable in GitHub Actions expressions — null comparison against a \`fromJson()\` array element doesn't consistently evaluate to \`true\` even when the element is a non-null string.

## Fix

\`find-successful-builds\` now also emits explicit string-boolean outputs:
- \`has_wiz_targets\`: \`'true'\` if the filtered Wiz matrix is non-empty
- \`has_os_integration_targets\`: \`'true'\` if the filtered os-integration matrix is non-empty

The downstream jobs gate on \`needs.find-successful-builds.outputs.has_X_targets == 'true'\`. Plain string comparison — reliable.

Also wraps PowerShell \`Where-Object\` results in \`@(...)\` so a single-item result serializes as a JSON array rather than a bare object, keeping the matrix valid.

Same fix applied to both \`gcp-fxci-parallel-alpha.yml\` and \`sig-FXCI-nontrusted-parallel-build-alpha.yml\`.

## Test plan

- [ ] Re-run \`gcp-fxci-parallel-alpha.yml\`. Confirm \`wiz-scan\` and \`os-integration\` matrix entries actually expand and start for the successful builds.
- [ ] Confirm the snap test (\`snap-upstream-test-basic-2404-amd64-nightly/opt\`) lands in the \`gw-fxci-gcp-l1-2404-gui-alpha\` os-integration task group.