### PR TITLE
Use empty-matrix-skip to gate filtered jobs

### DIFF
--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -113,8 +113,6 @@ jobs:
     outputs:
       wiz_matrix: ${{ steps.filter.outputs.wiz_matrix }}
       os_integration_matrix: ${{ steps.filter.outputs.os_integration_matrix }}
-      has_wiz_targets: ${{ steps.filter.outputs.has_wiz_targets }}
-      has_os_integration_targets: ${{ steps.filter.outputs.has_os_integration_targets }}
     steps:
       - id: filter
         name: Query run jobs API for successful packer entries
@@ -135,24 +133,19 @@ jobs:
           # Wiz runs against every successful non-trusted build.
           $wizConfigs = @($successful | Where-Object { $_ -notmatch '^trusted-' })
           $wizMatrix = @{ config = $wizConfigs } | ConvertTo-Json -Compress
-          Write-Host "wiz_matrix=$wizMatrix"
+          Write-Host "wiz_matrix=$wizMatrix (count=$($wizConfigs.Count))"
           "wiz_matrix=$wizMatrix" >> $env:GITHUB_OUTPUT
-          $hasWiz = if ($wizConfigs.Count -gt 0) { 'true' } else { 'false' }
-          "has_wiz_targets=$hasWiz" >> $env:GITHUB_OUTPUT
 
           # os-integration runs against configs that were both in the original
           # os_integration_matrix (level-1) AND succeeded in packer.
           $original = ConvertFrom-Json $env:ORIGINAL_OS_INT_MATRIX
           $osIntConfigs = @($original.config | Where-Object { $successful -contains $_ })
           $osIntMatrix = @{ config = $osIntConfigs } | ConvertTo-Json -Compress
-          Write-Host "os_integration_matrix=$osIntMatrix"
+          Write-Host "os_integration_matrix=$osIntMatrix (count=$($osIntConfigs.Count))"
           "os_integration_matrix=$osIntMatrix" >> $env:GITHUB_OUTPUT
-          $hasOsInt = if ($osIntConfigs.Count -gt 0) { 'true' } else { 'false' }
-          "has_os_integration_targets=$hasOsInt" >> $env:GITHUB_OUTPUT
 
   wiz-scan:
     needs: [find-successful-builds]
-    if: ${{ needs.find-successful-builds.outputs.has_wiz_targets == 'true' }}
     name: "Wiz Scan - ${{ matrix.config }}"
     runs-on: ubuntu-latest
     strategy:
@@ -193,7 +186,6 @@ jobs:
 
   os-integration:
     needs: [find-successful-builds]
-    if: ${{ needs.find-successful-builds.outputs.has_os_integration_targets == 'true' }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
+++ b/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
@@ -151,7 +151,6 @@ jobs:
       actions: read
     outputs:
       os_integration_matrix: ${{ steps.filter.outputs.os_integration_matrix }}
-      has_os_integration_targets: ${{ steps.filter.outputs.has_os_integration_targets }}
     steps:
       - id: filter
         name: Query run jobs API for successful packer entries
@@ -172,14 +171,11 @@ jobs:
           $original = ConvertFrom-Json $env:ORIGINAL_OS_INT_MATRIX
           $osIntConfigs = @($original.config | Where-Object { $successful -contains $_ })
           $osIntMatrix = @{ config = $osIntConfigs } | ConvertTo-Json -Compress
-          Write-Host "os_integration_matrix=$osIntMatrix"
+          Write-Host "os_integration_matrix=$osIntMatrix (count=$($osIntConfigs.Count))"
           "os_integration_matrix=$osIntMatrix" >> $env:GITHUB_OUTPUT
-          $hasOsInt = if ($osIntConfigs.Count -gt 0) { 'true' } else { 'false' }
-          "has_os_integration_targets=$hasOsInt" >> $env:GITHUB_OUTPUT
 
   os-integration:
     needs: [find-successful-builds]
-    if: ${{ needs.find-successful-builds.outputs.has_os_integration_targets == 'true' }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

#778's \`has_*_targets == 'true'\` gate also didn't work. [Run 25928180622](https://github.com/mozilla-platform-ops/worker-images/actions/runs/25928180622) shows the filter job correctly setting the outputs ("Set output 'has_wiz_targets'" / "Set output 'has_os_integration_targets'") and the populated matrices being emitted, but the downstream \`wiz-scan\` and \`os-integration\` jobs were still skipped with unexpanded \`\${{ matrix.config }}\` in their names.

Rather than chase a third \`if:\` syntax, lean on GitHub Actions' built-in behaviour: **a matrix job whose \`strategy.matrix\` resolves to an empty list is skipped automatically.**

## Fix

- Drop the \`if:\` gates on \`wiz-scan\` and \`os-integration\` in both workflows.
- Drop the \`has_*_targets\` outputs (no longer consumed).
- The filter already emits \`{"config":[]}\` for the no-targets case (PowerShell \`ConvertTo-Json -Compress\` is deterministic), so the matrix simply resolves to zero entries and the job is skipped.
- Add \`(count=N)\` to the \`Write-Host\` diagnostics in both filter jobs so future runs can confirm matrix size from a single log line.

## Test plan

- [ ] Re-run \`gcp-fxci-parallel-alpha.yml\`. Confirm \`wiz-scan\` and \`os-integration\` matrix entries expand and start for the level-1 configs that succeeded.
- [ ] Confirm the snap test (\`snap-upstream-test-basic-2404-amd64-nightly/opt\`) lands in the \`gw-fxci-gcp-l1-2404-gui-alpha\` os-integration task group.