### PR TITLE
Fix replicated gecko tasks: rewrite pool scopes and restore revision env

### DIFF
--- a/taskcluster/test/test_integration_test_transform.py
+++ b/taskcluster/test/test_integration_test_transform.py
@@ -12,16 +12,22 @@ def _load_module():
     taskgraph_module = types.ModuleType("taskgraph")
     transforms_module = types.ModuleType("taskgraph.transforms")
     base_module = types.ModuleType("taskgraph.transforms.base")
+    util_module = types.ModuleType("taskgraph.util")
+    util_taskcluster_module = types.ModuleType("taskgraph.util.taskcluster")
 
     class DummyTransformSequence:
         def add(self, fn):
             return fn
 
     setattr(base_module, "TransformSequence", DummyTransformSequence)
+    setattr(util_taskcluster_module, "find_task_id", lambda _: "stub-task-id")
+    setattr(util_taskcluster_module, "get_artifact", lambda *_: {})
 
     sys.modules["taskgraph"] = taskgraph_module
     sys.modules["taskgraph.transforms"] = transforms_module
     sys.modules["taskgraph.transforms.base"] = base_module
+    sys.modules["taskgraph.util"] = util_module
+    sys.modules["taskgraph.util.taskcluster"] = util_taskcluster_module
 
     fxci_module = types.ModuleType("worker_images_taskgraph.util.fxci")
     setattr(fxci_module, "get_worker_pool_images", lambda: {})
@@ -98,6 +104,51 @@ class TestIntegrationTestTransform(unittest.TestCase):
                 "generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap-alpha/snap_sudo",
                 "queue:scheduler-id:relops-level-1",
             ],
+        )
+
+
+    def test_restore_gecko_revision_env_injects_revs_for_gecko_tasks(self):
+        self.mod._fetch_gecko_revision_env = lambda: {
+            "GECKO_HEAD_REV": "deadbeefcafe",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/mozilla-central",
+        }
+
+        gecko_task = {
+            "attributes": {"replicate": "gecko"},
+            "task": {"payload": {"env": {"FOO": "bar"}}},
+        }
+        translations_task = {
+            "attributes": {"replicate": "translations"},
+            "task": {"payload": {"env": {}}},
+        }
+
+        result = list(
+            self.mod.restore_gecko_revision_env(
+                None, [gecko_task, translations_task]
+            )
+        )
+
+        self.assertEqual(
+            result[0]["task"]["payload"]["env"]["GECKO_HEAD_REV"], "deadbeefcafe"
+        )
+        self.assertEqual(result[0]["task"]["payload"]["env"]["FOO"], "bar")
+        # translations tasks are left alone
+        self.assertNotIn("GECKO_HEAD_REV", result[1]["task"]["payload"]["env"])
+
+    def test_restore_gecko_revision_env_does_not_overwrite_existing(self):
+        self.mod._fetch_gecko_revision_env = lambda: {
+            "GECKO_HEAD_REV": "newrev",
+        }
+
+        task = {
+            "attributes": {"replicate": "gecko"},
+            "task": {"payload": {"env": {"GECKO_HEAD_REV": "existingrev"}}},
+        }
+
+        result = list(self.mod.restore_gecko_revision_env(None, [task]))
+
+        self.assertEqual(
+            result[0]["task"]["payload"]["env"]["GECKO_HEAD_REV"], "existingrev"
         )
 
 

--- a/taskcluster/test/test_integration_test_transform.py
+++ b/taskcluster/test/test_integration_test_transform.py
@@ -63,6 +63,43 @@ class TestIntegrationTestTransform(unittest.TestCase):
 
         self.assertEqual(selected, "win11-a64-25h2-tester-alpha")
 
+    def test_change_worker_pool_to_alpha_rewrites_pool_bound_scopes(self):
+        # `change_worker_pool_to_alpha` imported get_worker_pool_images via
+        # `from ... import`, so patch the binding in the transform module itself.
+        self.mod.get_worker_pool_images = lambda: {
+            "gecko-t/t-linux-2404-wayland-snap-alpha": {
+                "gw-fxci-gcp-l1-2404-amd64-gui-googlecompute-alpha"
+            },
+        }
+
+        class DummyConfig:
+            kind = "integration-test"
+            params = {"images": ["gw-fxci-gcp-l1-2404-amd64-gui-googlecompute-alpha"]}
+
+        task = {
+            "task": {
+                "provisionerId": "gecko-t",
+                "workerType": "t-linux-2404-wayland-snap",
+                "scopes": [
+                    "generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap/snap_sudo",
+                    "queue:scheduler-id:relops-level-1",
+                ],
+            }
+        }
+
+        result = list(self.mod.change_worker_pool_to_alpha(DummyConfig(), [task]))
+
+        self.assertEqual(len(result), 1)
+        out = result[0]["task"]
+        self.assertEqual(out["workerType"], "t-linux-2404-wayland-snap-alpha")
+        self.assertEqual(
+            out["scopes"],
+            [
+                "generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap-alpha/snap_sudo",
+                "queue:scheduler-id:relops-level-1",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/taskcluster/worker_images_taskgraph/transforms/integration_test.py
+++ b/taskcluster/worker_images_taskgraph/transforms/integration_test.py
@@ -98,7 +98,16 @@ def change_worker_pool_to_alpha(config, tasks):
             )
             continue
 
+        new_pool = f"{provisioner_id}/{new_worker_type}"
         task["task"]["workerType"] = new_worker_type
+        # Pool-bound scopes (eg. generic-worker:os-group:<pool>/<group>)
+        # reference the original prod pool id. Rewrite them to the alpha
+        # pool so the alpha worker honors them and the decision task can
+        # create the task with scopes it actually holds.
+        if old_pool != new_pool and "scopes" in task["task"]:
+            task["task"]["scopes"] = [
+                scope.replace(old_pool, new_pool) for scope in task["task"]["scopes"]
+            ]
         yield task
 
 

--- a/taskcluster/worker_images_taskgraph/transforms/integration_test.py
+++ b/taskcluster/worker_images_taskgraph/transforms/integration_test.py
@@ -1,11 +1,43 @@
 import logging
+from functools import cache
 
 from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.taskcluster import find_task_id, get_artifact
 
 from worker_images_taskgraph.util.fxci import get_worker_pool_images
 
 logger = logging.getLogger(__name__)
 transforms = TransformSequence()
+
+GECKO_OS_INTEGRATION_INDEX = (
+    "gecko.v2.mozilla-central.latest.taskgraph.decision-os-integration"
+)
+
+
+@cache
+def _fetch_gecko_revision_env() -> dict[str, str]:
+    """Return the gecko revision env vars from the mc os-integration decision.
+
+    `mozilla_taskgraph.transforms.replicate` strips every `*_REV` env var from
+    replicated tasks. `run-task-hg` then can't find the revision to check out
+    and refuses with "task should be defined in terms of non-symbolic
+    revision". Re-fetch them from the decision task's `task-graph.json` so
+    replicated tasks check out the same gecko revision the decision ran on.
+    """
+    try:
+        decision_task_id = find_task_id(GECKO_OS_INTEGRATION_INDEX)
+        task_graph = get_artifact(decision_task_id, "public/task-graph.json")
+    except Exception as e:
+        logger.warning(f"could not fetch gecko os-integration decision: {e}")
+        return {}
+
+    for task in task_graph.values():
+        env = task.get("task", {}).get("payload", {}).get("env", {})
+        revs = {k: v for k, v in env.items() if k.endswith("_REV")}
+        if revs:
+            return revs
+
+    return {}
 
 
 def normalize_image_name(image_name: str) -> str:
@@ -108,6 +140,24 @@ def change_worker_pool_to_alpha(config, tasks):
             task["task"]["scopes"] = [
                 scope.replace(old_pool, new_pool) for scope in task["task"]["scopes"]
             ]
+        yield task
+
+
+@transforms.add
+def restore_gecko_revision_env(config, tasks):
+    """Re-inject `*_REV` env vars stripped by mozilla_taskgraph's replicate."""
+    revs = None
+    for task in tasks:
+        if task.get("attributes", {}).get("replicate") != "gecko":
+            yield task
+            continue
+
+        if revs is None:
+            revs = _fetch_gecko_revision_env()
+
+        env = task["task"].setdefault("payload", {}).setdefault("env", {})
+        for k, v in revs.items():
+            env.setdefault(k, v)
         yield task
 
 


### PR DESCRIPTION
## Summary

[Run 25930053384](https://github.com/mozilla-platform-ops/worker-images/actions/runs/25930053384) was the first time `gcp-fxci-parallel-alpha` actually scheduled os-integration test groups end-to-end (after #776 / #777 / #779 unblocked the workflow plumbing). It surfaced two pre-existing bugs in the replicate flow that prevent any gecko Linux test from running:

### 1. Pool-bound scopes not rewritten when worker-type is

`change_worker_pool_to_alpha` changes `workerType` from `<pool>` to `<pool>-alpha` but leaves task scopes alone. Pool-bound scopes like `generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap/snap_sudo` still reference the prod pool, so the decision task gets `InsufficientScopes` trying to create the task and (had it succeeded) the alpha-pool worker would refuse the os-group permission.

Fix: rewrite any scope string containing `<provisioner>/<old-pool>` to use the new alpha pool.

> Surfaced via:
> ```
> Client ID task-client/SDjGycEDTK6Ozbmf_H4-Pw/... missing
> generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap/snap_sudo
> ```
> (Needs companion grant in mozilla-releng/fxci-config#999.)

### 2. `*_REV` env vars stripped from replicated tasks

`mozilla_taskgraph.transforms.replicate._remove_revisions` deletes every `*_REV` env var from replicated tasks. Linux gecko tests then call `run-task-hg` with no `GECKO_HEAD_REV`, which refuses with "task should be defined in terms of non-symbolic revision". That's why all 24 of the `gecko-test-linux2404-64-asan/*` and friends failed in ~400ms.

Fix: new `restore_gecko_revision_env` transform that re-fetches the mc os-integration decision's `task-graph.json`, reads the `*_REV` env vars off any task (they're all from the same gecko revision), and injects them back. Pre-existing values on the task aren't overwritten. The decision lookup is `@cache`d so the whole replicated set shares one fetch. Only `attributes.replicate == "gecko"` tasks are touched.

## Test plan

- [ ] Land alongside mozilla-releng/fxci-config#999.
- [ ] Re-run `gcp-fxci-parallel-alpha.yml`. Confirm `snap-upstream-test-basic-2404-amd64-nightly/opt` is created and lands on `gecko-t/t-linux-2404-wayland-snap-alpha`.
- [ ] Confirm `gecko-test-linux2404-64-asan/opt-*` tasks now run past `run-task-hg` (they may still fail on test content — but should at least check out and start).