### PR TITLE
Walk translations pipeline ancestors for include-deps support

### DIFF
--- a/taskcluster/test/test_integration_test_transform.py
+++ b/taskcluster/test/test_integration_test_transform.py
@@ -22,6 +22,8 @@ def _load_module():
     setattr(base_module, "TransformSequence", DummyTransformSequence)
     setattr(util_taskcluster_module, "find_task_id", lambda _: "stub-task-id")
     setattr(util_taskcluster_module, "get_artifact", lambda *_: {})
+    setattr(util_taskcluster_module, "get_ancestors", lambda _: {})
+    setattr(util_taskcluster_module, "get_task_definition", lambda _: {})
 
     sys.modules["taskgraph"] = taskgraph_module
     sys.modules["taskgraph.transforms"] = transforms_module
@@ -134,6 +136,52 @@ class TestIntegrationTestTransform(unittest.TestCase):
         self.assertEqual(result[0]["task"]["payload"]["env"]["FOO"], "bar")
         # translations tasks are left alone
         self.assertNotIn("GECKO_HEAD_REV", result[1]["task"]["payload"]["env"])
+
+    def test_expand_translations_ancestors_replaces_placeholder(self):
+        # Pretend replicate emitted a single placeholder translations task and
+        # one unrelated gecko task. Stub the ancestor expansion to return two
+        # synthetic build taskdescs.
+        gecko_task = {
+            "label": "gecko-test-foo",
+            "attributes": {"replicate": "gecko"},
+            "task": {},
+        }
+        translations_placeholder = {
+            "label": "translations-all-pipeline-ru-en-1",
+            "attributes": {"replicate": "translations"},
+            "task": {"workerType": "succeed"},
+        }
+        synthesized = [
+            {"label": "translations-build-ru-en", "attributes": {"replicate": "translations"}, "task": {}},
+            {"label": "translations-train-ru-en", "attributes": {"replicate": "translations"}, "task": {}},
+        ]
+        self.mod._fetch_translations_ancestor_taskdescs = lambda: synthesized
+
+        result = list(
+            self.mod.expand_translations_ancestors(
+                None, [gecko_task, translations_placeholder]
+            )
+        )
+
+        labels = [t["label"] for t in result]
+        # Placeholder is dropped; gecko untouched; synthesized translations added
+        self.assertIn("gecko-test-foo", labels)
+        self.assertNotIn("translations-all-pipeline-ru-en-1", labels)
+        self.assertIn("translations-build-ru-en", labels)
+        self.assertIn("translations-train-ru-en", labels)
+
+    def test_expand_translations_ancestors_skips_when_no_translations(self):
+        # No translations task in input => no upstream lookup, output equals input.
+        self.mod._fetch_translations_ancestor_taskdescs = lambda: [
+            {"label": "translations-should-not-appear", "attributes": {"replicate": "translations"}, "task": {}},
+        ]
+        gecko_only = [
+            {"label": "gecko-test-foo", "attributes": {"replicate": "gecko"}, "task": {}},
+        ]
+
+        result = list(self.mod.expand_translations_ancestors(None, gecko_only))
+
+        self.assertEqual([t["label"] for t in result], ["gecko-test-foo"])
 
     def test_restore_gecko_revision_env_does_not_overwrite_existing(self):
         self.mod._fetch_gecko_revision_env = lambda: {

--- a/taskcluster/worker_images_taskgraph/transforms/integration_test.py
+++ b/taskcluster/worker_images_taskgraph/transforms/integration_test.py
@@ -1,8 +1,14 @@
 import logging
+import re
 from functools import cache
 
 from taskgraph.transforms.base import TransformSequence
-from taskgraph.util.taskcluster import find_task_id, get_artifact
+from taskgraph.util.taskcluster import (
+    find_task_id,
+    get_ancestors,
+    get_artifact,
+    get_task_definition,
+)
 
 from worker_images_taskgraph.util.fxci import get_worker_pool_images
 
@@ -11,6 +17,15 @@ transforms = TransformSequence()
 
 GECKO_OS_INTEGRATION_INDEX = (
     "gecko.v2.mozilla-central.latest.taskgraph.decision-os-integration"
+)
+TRANSLATIONS_PIPELINE_INDEX = (
+    "translations.v2.translations.latest.taskgraph.decision-run-pipeline"
+)
+# Walk ancestors of the translations all-pipeline task. Skip the decision /
+# action / docker-image tasks (their definitions don't survive replication).
+# Mirrors `include-deps` in `taskcluster/kinds/integration-test/kind.yml`.
+TRANSLATIONS_INCLUDE_DEPS = re.compile(
+    r"^(?!(Decision|Action|PR action|build-docker-image|docker-image)).*"
 )
 
 
@@ -38,6 +53,105 @@ def _fetch_gecko_revision_env() -> dict[str, str]:
             return revs
 
     return {}
+
+
+def _rewrite_datestamps(task_def: dict) -> None:
+    """Make timestamps relative so the replicated task can be re-scheduled."""
+    task_def["created"] = {"relative-datestamp": "0 seconds"}
+    task_def["deadline"] = {"relative-datestamp": "1 day"}
+    task_def["expires"] = {"relative-datestamp": "1 month"}
+
+    payload = task_def.get("payload", {})
+    artifacts = payload.get("artifacts")
+    if isinstance(artifacts, dict):
+        for k in artifacts:
+            if "expires" in artifacts[k]:
+                artifacts[k]["expires"] = {"relative-datestamp": "1 month"}
+    elif isinstance(artifacts, list):
+        for a in artifacts:
+            if "expires" in a:
+                a["expires"] = {"relative-datestamp": "1 month"}
+
+
+def _remove_revisions(task_def: dict) -> None:
+    """Strip absolute `*_REV` env vars to avoid pointing at stale revisions."""
+    env = task_def.get("payload", {}).get("env", {})
+    for k in [k for k in env if k.endswith("_REV")]:
+        del env[k]
+
+
+def _replicate_ancestor_task(name_prefix: str, task_def: dict) -> dict:
+    """Normalize an upstream task definition into a replicated task description.
+
+    Matches the shape `mozilla_taskgraph.transforms.replicate` produces for the
+    original target tasks: name-prefixed, datestamps rewritten, scopes/level
+    dropped from 3 to 1, and no leftover dependencies.
+    """
+    _rewrite_datestamps(task_def)
+    _remove_revisions(task_def)
+
+    # taskQueueId never matches the staging cluster; let provisionerId/workerType
+    # be the source of truth.
+    task_def.pop("taskQueueId", None)
+    for key in ("provisionerId", "workerType"):
+        if key in task_def:
+            task_def[key] = task_def[key].replace("3", "1")
+
+    for i, scope in enumerate(task_def.get("scopes", [])):
+        task_def["scopes"][i] = scope.replace("gecko-level-3", "releng-level-1")
+
+    orig_name = task_def["metadata"]["name"]
+    task_def["metadata"]["name"] = f"{name_prefix}-{orig_name}"
+
+    return {
+        "label": task_def["metadata"]["name"],
+        "dependencies": {},
+        "description": task_def["metadata"].get("description", ""),
+        "task": task_def,
+        "attributes": {"replicate": name_prefix},
+    }
+
+
+@cache
+def _fetch_translations_ancestor_taskdescs() -> list[dict]:
+    """Return replicated taskdescs for ancestors of the translations pipeline.
+
+    `mozilla_taskgraph.transforms.replicate` doesn't honor `include-deps`, so
+    only the synthetic `all-pipeline` task (a `succeed` pseudo-worker) survives
+    the default flow. Walk that task's ancestors via Taskcluster's queue API
+    to pull in the real translations build/run tasks, mirroring the logic in
+    `fxci_config_taskgraph.util.integration.find_tasks`.
+    """
+    try:
+        decision_task_id = find_task_id(TRANSLATIONS_PIPELINE_INDEX)
+        task_graph = get_artifact(decision_task_id, "public/task-graph.json")
+    except Exception as e:
+        logger.warning(f"could not fetch translations decision: {e}")
+        return []
+
+    ancestor_ids: set[str] = set()
+    for tid, t in task_graph.items():
+        if t.get("attributes", {}).get("stage") != "all-pipeline":
+            continue
+        try:
+            ancestors = get_ancestors(tid)
+        except Exception as e:
+            logger.warning(f"get_ancestors failed for {tid}: {e}")
+            continue
+        for aid, label in ancestors.items():
+            if TRANSLATIONS_INCLUDE_DEPS.match(label):
+                ancestor_ids.add(aid)
+
+    taskdescs: list[dict] = []
+    for aid in ancestor_ids:
+        try:
+            task_def = get_task_definition(aid)
+        except Exception as e:
+            logger.warning(f"get_task_definition failed for {aid}: {e}")
+            continue
+        taskdescs.append(_replicate_ancestor_task("translations", task_def))
+
+    return taskdescs
 
 
 def normalize_image_name(image_name: str) -> str:
@@ -106,6 +220,32 @@ def get_image_compatible_alpha_worker_type(
             return candidate_worker_type
 
     return default_worker_type if default_pool in pool_images_by_pool else None
+
+
+@transforms.add
+def expand_translations_ancestors(config, tasks):
+    """Replace replicate's translations output with ancestor-walked tasks.
+
+    `mozilla_taskgraph.transforms.replicate` silently ignores `include-deps`, so
+    the translations entry in `kind.yml` only ever produces a single
+    `succeed`-typed placeholder (no `-alpha` pool exists for the built-in
+    `succeed` worker, so even that gets dropped downstream and translations
+    effectively never validates anything). Drop replicate's translations
+    placeholder and emit replicated taskdescs for the real ancestor tasks
+    (build/pipeline steps) instead.
+    """
+    has_translations = False
+    for task in tasks:
+        if task.get("attributes", {}).get("replicate") == "translations":
+            has_translations = True
+            continue
+        yield task
+
+    if not has_translations:
+        return
+
+    for taskdesc in _fetch_translations_ancestor_taskdescs():
+        yield taskdesc
 
 
 @transforms.add


### PR DESCRIPTION
## Summary

`mozilla_taskgraph.transforms.replicate` silently ignores the `include-deps` field in `kind.yml`. The translations entry there only ever resolves to one synthetic `all-pipeline` placeholder task pointing at the `succeed` pseudo-worker — and since there's no `succeed-alpha` pool, even that gets dropped by `change_worker_pool_to_alpha`. Net result: the worker-images image-validation cron emits **zero** translations tasks no matter which candidate image you give it.

Compare with fxci-config, which implements its own `find_tasks` ([`taskcluster/fxci_config_taskgraph/util/integration.py:117-193`](https://github.com/mozilla-releng/fxci-config/blob/main/taskcluster/fxci_config_taskgraph/util/integration.py)) that handles `include-deps` by walking ancestors via Taskcluster's queue API.

## Fix

Mirror that logic in a new `expand_translations_ancestors` transform that runs after `mozilla_taskgraph.transforms.replicate` but before `change_worker_pool_to_alpha`:

1. Drop the translations placeholder replicate emitted.
2. Look up the `translations.v2.translations.latest.taskgraph.decision-run-pipeline` decision.
3. Find tasks with `attributes.stage == "all-pipeline"`.
4. For each, call `get_ancestors` and filter labels by the include-deps regex.
5. Fetch each ancestor's task definition via `get_task_definition`.
6. Normalize (rewrite datestamps, strip `*_REV`, drop level-3 → 1, scope rewrites) and emit as replicated taskdescs with the `translations-` name prefix.

The new tasks then flow through the existing `change_worker_pool_to_alpha` (which retargets `translations-1/<pool>` → `translations-1/<pool>-alpha` — those alpha pools do exist) and the `IntegrationTestStrategy` optimization (which keeps them only when their pool's image matches the candidate image).

Gecko handling is untouched.

## Test plan

- [ ] Re-run `gcp-fxci-parallel-alpha.yml` and confirm the `headless-alpha` and `arm64-headless-alpha` os-integration jobs now schedule `translations-*` tasks against `translations-1/*-alpha` pools.
- [ ] Confirm gecko replication is unchanged (still produces ~29 gecko-prefixed tasks per image).