### PR TITLE
Skip alpha retargeting for translations integration tasks

### DIFF
--- a/taskcluster/test/test_integration_test_transform.py
+++ b/taskcluster/test/test_integration_test_transform.py
@@ -137,6 +137,33 @@ class TestIntegrationTestTransform(unittest.TestCase):
         # translations tasks are left alone
         self.assertNotIn("GECKO_HEAD_REV", result[1]["task"]["payload"]["env"])
 
+    def test_change_worker_pool_to_alpha_skips_translations_tasks(self):
+        # Translations build pools don't have `-alpha` variants. Make sure
+        # the transform leaves translations tasks alone instead of dropping
+        # them via the "no -alpha pool" code path.
+        self.mod.get_worker_pool_images = lambda: {}
+
+        class DummyConfig:
+            kind = "integration-test"
+            params = {"images": ["whatever"]}
+
+        trans = {
+            "attributes": {"replicate": "translations"},
+            "task": {
+                "provisionerId": "translations-1",
+                "workerType": "b-linux-large-gcp-d2g",
+                "scopes": [],
+            },
+        }
+
+        result = list(self.mod.change_worker_pool_to_alpha(DummyConfig(), [trans]))
+
+        self.assertEqual(len(result), 1)
+        # Worker-type / scopes unchanged
+        self.assertEqual(
+            result[0]["task"]["workerType"], "b-linux-large-gcp-d2g"
+        )
+
     def test_expand_translations_ancestors_replaces_placeholder(self):
         # Pretend replicate emitted a single placeholder translations task and
         # one unrelated gecko task. Stub the ancestor expansion to return two

--- a/taskcluster/worker_images_taskgraph/optimize.py
+++ b/taskcluster/worker_images_taskgraph/optimize.py
@@ -11,6 +11,11 @@ from worker_images_taskgraph.util.fxci import get_worker_pool_images
 class IntegrationTestStrategy(OptimizationStrategy):
 
     def should_remove_task(self, task, params, _) -> bool:
+        # Translations tasks stay on their prod pool (no `-alpha` retargeting),
+        # so the candidate image filter doesn't apply to them. Always keep them.
+        if task.attributes.get("replicate") == "translations":
+            return False
+
         task_queue_id = f"{task.task['provisionerId']}/{task.task['workerType']}"
         pool_images = get_worker_pool_images().get(task_queue_id, set())
 

--- a/taskcluster/worker_images_taskgraph/transforms/integration_test.py
+++ b/taskcluster/worker_images_taskgraph/transforms/integration_test.py
@@ -254,6 +254,14 @@ def change_worker_pool_to_alpha(config, tasks):
     requested_images = get_normalized_images(list(config.params.get("images") or []))
 
     for task in tasks:
+        # Translations build pools don't have `-alpha` variants and aren't
+        # what we're validating in an image bump anyway. Keep them on the
+        # prod pool (already level-1 from the replicate step), matching
+        # the fxci-config PR behavior of "drop level, don't append -alpha".
+        if task.get("attributes", {}).get("replicate") == "translations":
+            yield task
+            continue
+
         provisioner_id = task["task"]["provisionerId"]
         worker_type = task["task"]["workerType"]
         old_pool = f"{provisioner_id}/{worker_type}"


### PR DESCRIPTION
## Summary

PR #781 made the worker-images cron correctly walk the translations decision's ancestors via `include-deps` — but they immediately get dropped because the translations build pools (`translations-1/b-linux-large-gcp-d2g`, `b-linux-large-gcp-d2g-100gb`, `b-linux-large-gcp-1tb-12-256-d2g`, `scriptworker-k8s/translations-1-beetmover`) don't have `-alpha` variants in fxci-config.

That's actually the right state of the world — `-alpha` variants exist for gecko-t test pools that we validate against new images, not for translations build pools. Translations doesn't have an "image bump" use case the way gecko-t does.

This matches the fxci-config integration test pattern, which only drops the level (3 → 1) and keeps the original worker-type — so translations tasks land on `translations-1/<pool>` on the staging cluster regardless of what image is being validated.

## Fix

- `change_worker_pool_to_alpha`: bypass tasks whose `attributes.replicate == "translations"`. They keep their original worker-type.
- `IntegrationTestStrategy.should_remove_task`: always keep translations tasks regardless of whether their pool's image matches the candidate image. (Otherwise they'd be optimized out because their prod pool's image isn't the candidate alpha image.)

Net result: translations integration tasks run on every cron fire against their prod pool at level 1, validating "the translations pipeline still works", which mirrors what fxci-config PR comments do. Gecko tasks still get full `-alpha` retargeting + image filtering.

## Test plan

- [ ] Re-run `gcp-fxci-parallel-alpha.yml`. Confirm the headless / arm64-headless / gui-alpha os-integration jobs now schedule `translations-*` tasks on `translations-1/<pool>` (no `-alpha` suffix).
- [ ] Confirm gecko replication is unchanged (still produces ~29 gecko-prefixed tasks per image, targeting `-alpha` pools).