### PR TITLE
Dedupe translations ancestors by label, not task ID

### DIFF
--- a/taskcluster/worker_images_taskgraph/transforms/integration_test.py
+++ b/taskcluster/worker_images_taskgraph/transforms/integration_test.py
@@ -129,7 +129,11 @@ def _fetch_translations_ancestor_taskdescs() -> list[dict]:
         logger.warning(f"could not fetch translations decision: {e}")
         return []
 
-    ancestor_ids: set[str] = set()
+    # Different ancestor task IDs can share the same task name (eg. cached
+    # toolchain-cuda-toolkit tasks from different decision runs). Replicating
+    # both would produce duplicate `translations-<name>` labels and crash
+    # taskgraph generation. Dedupe by label, keeping the first task ID seen.
+    ancestor_id_by_label: dict[str, str] = {}
     for tid, t in task_graph.items():
         if t.get("attributes", {}).get("stage") != "all-pipeline":
             continue
@@ -140,10 +144,10 @@ def _fetch_translations_ancestor_taskdescs() -> list[dict]:
             continue
         for aid, label in ancestors.items():
             if TRANSLATIONS_INCLUDE_DEPS.match(label):
-                ancestor_ids.add(aid)
+                ancestor_id_by_label.setdefault(label, aid)
 
     taskdescs: list[dict] = []
-    for aid in ancestor_ids:
+    for aid in ancestor_id_by_label.values():
         try:
             task_def = get_task_definition(aid)
         except Exception as e:


### PR DESCRIPTION
## Summary

[Run 25938679449](https://github.com/mozilla-platform-ops/worker-images/actions/runs/25938679449) had all three os-integration jobs fail with:

```
Exception: duplicate tasks with label translations-toolchain-cuda-toolkit
```

`get_ancestors` returns `{task_id: label}`. The translations pipeline often has multiple task IDs sharing the same name (cached `toolchain-cuda-toolkit` from prior decision runs, for instance). The previous set-based dedup was by task_id (each unique), so both made it through; `_replicate_ancestor_task` then prefixed both to `translations-toolchain-cuda-toolkit` and taskgraph rejected the duplicate label.

## Fix

Dedupe by label up front via `setdefault(label, aid)`. First task_id per label wins; later ones are skipped.

## Verification

Local `taskgraph full -p taskcluster/test/params/cron-run-integration-tests.yml` now succeeds:

```
total tasks: 253
  gecko-prefixed: 88
  translations-prefixed: 164
  duplicate labels: 0
  cuda-related labels: ['translations-fetch-cuda', 'translations-toolchain-cuda-toolkit']
```

`translations-toolchain-cuda-toolkit` appears exactly once instead of twice.

## Test plan

- [ ] Re-run `gcp-fxci-parallel-alpha.yml`. Confirm decision tasks succeed (no duplicate-label crash) and translations tasks appear in the task groups.