### PR TITLE
Force wiz-scan / os-integration after partial packer failures

### DIFF
--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -146,6 +146,7 @@ jobs:
 
   wiz-scan:
     needs: [find-successful-builds]
+    if: ${{ !cancelled() && needs.find-successful-builds.result == 'success' }}
     name: "Wiz Scan - ${{ matrix.config }}"
     runs-on: ubuntu-latest
     strategy:
@@ -186,6 +187,7 @@ jobs:
 
   os-integration:
     needs: [find-successful-builds]
+    if: ${{ !cancelled() && needs.find-successful-builds.result == 'success' }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
+++ b/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
@@ -176,6 +176,7 @@ jobs:
 
   os-integration:
     needs: [find-successful-builds]
+    if: ${{ !cancelled() && needs.find-successful-builds.result == 'success' }}
     name: "OS Integration Tests - ${{ matrix.config }}"
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

[Run 25940708014](https://github.com/mozilla-platform-ops/worker-images/actions/runs/25940708014) had `gw-fxci-gcp-l1-2404-headless-alpha` and `gw-fxci-gcp-l1-2404-gui-alpha` build cleanly, but both arm64 packer entries failed (GCP stockout again). `find-successful-builds` then emitted a populated matrix:

```
wiz_matrix={"config":["gw-fxci-gcp-l1-2404-headless-alpha","gw-fxci-gcp-l1-2404-gui-alpha"]} (count=2)
os_integration_matrix={"config":["gw-fxci-gcp-l1-2404-gui-alpha","gw-fxci-gcp-l1-2404-headless-alpha"]} (count=2)
```

…but `wiz-scan` and `os-integration` were both skipped with `${{ matrix.config }}` unexpanded in the job name. PR #779 removed the explicit `if:` in favor of empty-matrix-skip, which works when the packer chain is clean — but GitHub Actions transitively propagates packer failures through `needs:` and skips downstream jobs even when their immediate `needs` (find-successful-builds) succeeded.

## Fix

`if: ${{ !cancelled() && needs.find-successful-builds.result == 'success' }}` on both `wiz-scan` and `os-integration`. The filter job is the canonical "did we produce anything to do" signal; deferring to its result lets the downstream jobs fire regardless of how many packer entries failed.

Applied to both `gcp-fxci-parallel-alpha.yml` and `sig-FXCI-nontrusted-parallel-build-alpha.yml`.

## Test plan

- [ ] Re-run `gcp-fxci-parallel-alpha.yml`. Confirm wiz-scan and os-integration both expand and run for the successful packer configs even when arm64 builds fail.