### PR TITLE
Drop translations from worker-images integration-test kind

### DIFF
--- a/taskcluster/kinds/integration-test/kind.yml
+++ b/taskcluster/kinds/integration-test/kind.yml
@@ -27,19 +27,3 @@ tasks:
         test_platform:
           - android-hw
           - macosx
-
-  translations:
-    description: "Run translations pipeline integration tests"
-    replicate:
-      target:
-        - translations.v2.translations.latest.taskgraph.decision-run-pipeline
-      include-attrs:
-        # Corresponds to https://github.com/mozilla/translations/blob/main/taskcluster/kinds/all-pipeline/kind.yml
-        stage:
-          - all-pipeline
-      include-deps:
-        # Decision and Action tasks are excluded because we'll be creating the
-        # tasks they normally would be.
-        # docker-image tasks are excluded because there's no value in rerunning
-        # them as part of integration tests.
-        - ^(?!(Decision|Action|PR action|build-docker-image|docker-image)).*

--- a/taskcluster/test/test_integration_test_transform.py
+++ b/taskcluster/test/test_integration_test_transform.py
@@ -22,8 +22,6 @@ def _load_module():
     setattr(base_module, "TransformSequence", DummyTransformSequence)
     setattr(util_taskcluster_module, "find_task_id", lambda _: "stub-task-id")
     setattr(util_taskcluster_module, "get_artifact", lambda *_: {})
-    setattr(util_taskcluster_module, "get_ancestors", lambda _: {})
-    setattr(util_taskcluster_module, "get_task_definition", lambda _: {})
 
     sys.modules["taskgraph"] = taskgraph_module
     sys.modules["taskgraph.transforms"] = transforms_module
@@ -108,7 +106,6 @@ class TestIntegrationTestTransform(unittest.TestCase):
             ],
         )
 
-
     def test_restore_gecko_revision_env_injects_revs_for_gecko_tasks(self):
         self.mod._fetch_gecko_revision_env = lambda: {
             "GECKO_HEAD_REV": "deadbeefcafe",
@@ -119,14 +116,14 @@ class TestIntegrationTestTransform(unittest.TestCase):
             "attributes": {"replicate": "gecko"},
             "task": {"payload": {"env": {"FOO": "bar"}}},
         }
-        translations_task = {
-            "attributes": {"replicate": "translations"},
+        non_gecko_task = {
+            "attributes": {"replicate": "other"},
             "task": {"payload": {"env": {}}},
         }
 
         result = list(
             self.mod.restore_gecko_revision_env(
-                None, [gecko_task, translations_task]
+                None, [gecko_task, non_gecko_task]
             )
         )
 
@@ -134,81 +131,8 @@ class TestIntegrationTestTransform(unittest.TestCase):
             result[0]["task"]["payload"]["env"]["GECKO_HEAD_REV"], "deadbeefcafe"
         )
         self.assertEqual(result[0]["task"]["payload"]["env"]["FOO"], "bar")
-        # translations tasks are left alone
+        # non-gecko tasks are left alone
         self.assertNotIn("GECKO_HEAD_REV", result[1]["task"]["payload"]["env"])
-
-    def test_change_worker_pool_to_alpha_skips_translations_tasks(self):
-        # Translations build pools don't have `-alpha` variants. Make sure
-        # the transform leaves translations tasks alone instead of dropping
-        # them via the "no -alpha pool" code path.
-        self.mod.get_worker_pool_images = lambda: {}
-
-        class DummyConfig:
-            kind = "integration-test"
-            params = {"images": ["whatever"]}
-
-        trans = {
-            "attributes": {"replicate": "translations"},
-            "task": {
-                "provisionerId": "translations-1",
-                "workerType": "b-linux-large-gcp-d2g",
-                "scopes": [],
-            },
-        }
-
-        result = list(self.mod.change_worker_pool_to_alpha(DummyConfig(), [trans]))
-
-        self.assertEqual(len(result), 1)
-        # Worker-type / scopes unchanged
-        self.assertEqual(
-            result[0]["task"]["workerType"], "b-linux-large-gcp-d2g"
-        )
-
-    def test_expand_translations_ancestors_replaces_placeholder(self):
-        # Pretend replicate emitted a single placeholder translations task and
-        # one unrelated gecko task. Stub the ancestor expansion to return two
-        # synthetic build taskdescs.
-        gecko_task = {
-            "label": "gecko-test-foo",
-            "attributes": {"replicate": "gecko"},
-            "task": {},
-        }
-        translations_placeholder = {
-            "label": "translations-all-pipeline-ru-en-1",
-            "attributes": {"replicate": "translations"},
-            "task": {"workerType": "succeed"},
-        }
-        synthesized = [
-            {"label": "translations-build-ru-en", "attributes": {"replicate": "translations"}, "task": {}},
-            {"label": "translations-train-ru-en", "attributes": {"replicate": "translations"}, "task": {}},
-        ]
-        self.mod._fetch_translations_ancestor_taskdescs = lambda: synthesized
-
-        result = list(
-            self.mod.expand_translations_ancestors(
-                None, [gecko_task, translations_placeholder]
-            )
-        )
-
-        labels = [t["label"] for t in result]
-        # Placeholder is dropped; gecko untouched; synthesized translations added
-        self.assertIn("gecko-test-foo", labels)
-        self.assertNotIn("translations-all-pipeline-ru-en-1", labels)
-        self.assertIn("translations-build-ru-en", labels)
-        self.assertIn("translations-train-ru-en", labels)
-
-    def test_expand_translations_ancestors_skips_when_no_translations(self):
-        # No translations task in input => no upstream lookup, output equals input.
-        self.mod._fetch_translations_ancestor_taskdescs = lambda: [
-            {"label": "translations-should-not-appear", "attributes": {"replicate": "translations"}, "task": {}},
-        ]
-        gecko_only = [
-            {"label": "gecko-test-foo", "attributes": {"replicate": "gecko"}, "task": {}},
-        ]
-
-        result = list(self.mod.expand_translations_ancestors(None, gecko_only))
-
-        self.assertEqual([t["label"] for t in result], ["gecko-test-foo"])
 
     def test_restore_gecko_revision_env_does_not_overwrite_existing(self):
         self.mod._fetch_gecko_revision_env = lambda: {

--- a/taskcluster/worker_images_taskgraph/optimize.py
+++ b/taskcluster/worker_images_taskgraph/optimize.py
@@ -11,11 +11,6 @@ from worker_images_taskgraph.util.fxci import get_worker_pool_images
 class IntegrationTestStrategy(OptimizationStrategy):
 
     def should_remove_task(self, task, params, _) -> bool:
-        # Translations tasks stay on their prod pool (no `-alpha` retargeting),
-        # so the candidate image filter doesn't apply to them. Always keep them.
-        if task.attributes.get("replicate") == "translations":
-            return False
-
         task_queue_id = f"{task.task['provisionerId']}/{task.task['workerType']}"
         pool_images = get_worker_pool_images().get(task_queue_id, set())
 

--- a/taskcluster/worker_images_taskgraph/transforms/integration_test.py
+++ b/taskcluster/worker_images_taskgraph/transforms/integration_test.py
@@ -1,14 +1,8 @@
 import logging
-import re
 from functools import cache
 
 from taskgraph.transforms.base import TransformSequence
-from taskgraph.util.taskcluster import (
-    find_task_id,
-    get_ancestors,
-    get_artifact,
-    get_task_definition,
-)
+from taskgraph.util.taskcluster import find_task_id, get_artifact
 
 from worker_images_taskgraph.util.fxci import get_worker_pool_images
 
@@ -17,15 +11,6 @@ transforms = TransformSequence()
 
 GECKO_OS_INTEGRATION_INDEX = (
     "gecko.v2.mozilla-central.latest.taskgraph.decision-os-integration"
-)
-TRANSLATIONS_PIPELINE_INDEX = (
-    "translations.v2.translations.latest.taskgraph.decision-run-pipeline"
-)
-# Walk ancestors of the translations all-pipeline task. Skip the decision /
-# action / docker-image tasks (their definitions don't survive replication).
-# Mirrors `include-deps` in `taskcluster/kinds/integration-test/kind.yml`.
-TRANSLATIONS_INCLUDE_DEPS = re.compile(
-    r"^(?!(Decision|Action|PR action|build-docker-image|docker-image)).*"
 )
 
 
@@ -53,109 +38,6 @@ def _fetch_gecko_revision_env() -> dict[str, str]:
             return revs
 
     return {}
-
-
-def _rewrite_datestamps(task_def: dict) -> None:
-    """Make timestamps relative so the replicated task can be re-scheduled."""
-    task_def["created"] = {"relative-datestamp": "0 seconds"}
-    task_def["deadline"] = {"relative-datestamp": "1 day"}
-    task_def["expires"] = {"relative-datestamp": "1 month"}
-
-    payload = task_def.get("payload", {})
-    artifacts = payload.get("artifacts")
-    if isinstance(artifacts, dict):
-        for k in artifacts:
-            if "expires" in artifacts[k]:
-                artifacts[k]["expires"] = {"relative-datestamp": "1 month"}
-    elif isinstance(artifacts, list):
-        for a in artifacts:
-            if "expires" in a:
-                a["expires"] = {"relative-datestamp": "1 month"}
-
-
-def _remove_revisions(task_def: dict) -> None:
-    """Strip absolute `*_REV` env vars to avoid pointing at stale revisions."""
-    env = task_def.get("payload", {}).get("env", {})
-    for k in [k for k in env if k.endswith("_REV")]:
-        del env[k]
-
-
-def _replicate_ancestor_task(name_prefix: str, task_def: dict) -> dict:
-    """Normalize an upstream task definition into a replicated task description.
-
-    Matches the shape `mozilla_taskgraph.transforms.replicate` produces for the
-    original target tasks: name-prefixed, datestamps rewritten, scopes/level
-    dropped from 3 to 1, and no leftover dependencies.
-    """
-    _rewrite_datestamps(task_def)
-    _remove_revisions(task_def)
-
-    # taskQueueId never matches the staging cluster; let provisionerId/workerType
-    # be the source of truth.
-    task_def.pop("taskQueueId", None)
-    for key in ("provisionerId", "workerType"):
-        if key in task_def:
-            task_def[key] = task_def[key].replace("3", "1")
-
-    for i, scope in enumerate(task_def.get("scopes", [])):
-        task_def["scopes"][i] = scope.replace("gecko-level-3", "releng-level-1")
-
-    orig_name = task_def["metadata"]["name"]
-    task_def["metadata"]["name"] = f"{name_prefix}-{orig_name}"
-
-    return {
-        "label": task_def["metadata"]["name"],
-        "dependencies": {},
-        "description": task_def["metadata"].get("description", ""),
-        "task": task_def,
-        "attributes": {"replicate": name_prefix},
-    }
-
-
-@cache
-def _fetch_translations_ancestor_taskdescs() -> list[dict]:
-    """Return replicated taskdescs for ancestors of the translations pipeline.
-
-    `mozilla_taskgraph.transforms.replicate` doesn't honor `include-deps`, so
-    only the synthetic `all-pipeline` task (a `succeed` pseudo-worker) survives
-    the default flow. Walk that task's ancestors via Taskcluster's queue API
-    to pull in the real translations build/run tasks, mirroring the logic in
-    `fxci_config_taskgraph.util.integration.find_tasks`.
-    """
-    try:
-        decision_task_id = find_task_id(TRANSLATIONS_PIPELINE_INDEX)
-        task_graph = get_artifact(decision_task_id, "public/task-graph.json")
-    except Exception as e:
-        logger.warning(f"could not fetch translations decision: {e}")
-        return []
-
-    # Different ancestor task IDs can share the same task name (eg. cached
-    # toolchain-cuda-toolkit tasks from different decision runs). Replicating
-    # both would produce duplicate `translations-<name>` labels and crash
-    # taskgraph generation. Dedupe by label, keeping the first task ID seen.
-    ancestor_id_by_label: dict[str, str] = {}
-    for tid, t in task_graph.items():
-        if t.get("attributes", {}).get("stage") != "all-pipeline":
-            continue
-        try:
-            ancestors = get_ancestors(tid)
-        except Exception as e:
-            logger.warning(f"get_ancestors failed for {tid}: {e}")
-            continue
-        for aid, label in ancestors.items():
-            if TRANSLATIONS_INCLUDE_DEPS.match(label):
-                ancestor_id_by_label.setdefault(label, aid)
-
-    taskdescs: list[dict] = []
-    for aid in ancestor_id_by_label.values():
-        try:
-            task_def = get_task_definition(aid)
-        except Exception as e:
-            logger.warning(f"get_task_definition failed for {aid}: {e}")
-            continue
-        taskdescs.append(_replicate_ancestor_task("translations", task_def))
-
-    return taskdescs
 
 
 def normalize_image_name(image_name: str) -> str:
@@ -227,45 +109,11 @@ def get_image_compatible_alpha_worker_type(
 
 
 @transforms.add
-def expand_translations_ancestors(config, tasks):
-    """Replace replicate's translations output with ancestor-walked tasks.
-
-    `mozilla_taskgraph.transforms.replicate` silently ignores `include-deps`, so
-    the translations entry in `kind.yml` only ever produces a single
-    `succeed`-typed placeholder (no `-alpha` pool exists for the built-in
-    `succeed` worker, so even that gets dropped downstream and translations
-    effectively never validates anything). Drop replicate's translations
-    placeholder and emit replicated taskdescs for the real ancestor tasks
-    (build/pipeline steps) instead.
-    """
-    has_translations = False
-    for task in tasks:
-        if task.get("attributes", {}).get("replicate") == "translations":
-            has_translations = True
-            continue
-        yield task
-
-    if not has_translations:
-        return
-
-    for taskdesc in _fetch_translations_ancestor_taskdescs():
-        yield taskdesc
-
-
-@transforms.add
 def change_worker_pool_to_alpha(config, tasks):
     pool_images_by_pool = get_worker_pool_images()
     requested_images = get_normalized_images(list(config.params.get("images") or []))
 
     for task in tasks:
-        # Translations build pools don't have `-alpha` variants and aren't
-        # what we're validating in an image bump anyway. Keep them on the
-        # prod pool (already level-1 from the replicate step), matching
-        # the fxci-config PR behavior of "drop level, don't append -alpha".
-        if task.get("attributes", {}).get("replicate") == "translations":
-            yield task
-            continue
-
         provisioner_id = task["task"]["provisionerId"]
         worker_type = task["task"]["workerType"]
         old_pool = f"{provisioner_id}/{worker_type}"


### PR DESCRIPTION
## Summary

Reverts the translations-related changes (PRs #781, #782, #783) and removes the long-standing dead `translations` entry from `taskcluster/kinds/integration-test/kind.yml`. The goal of Bug 1941642 is **Linux Wayland 24.04 image validation via gecko os-integration**, not translations pipeline validation — and the translations work was producing noise:

- `mozilla_taskgraph.transforms.replicate` doesn't honor `include-deps`, so the kind only ever produced a `succeed` placeholder.
- Walking `all-pipeline` ancestors via the queue API surfaced cached duplicate labels (`translations-toolchain-cuda-toolkit`) that crashed the decision task.
- Even with dedupe, translations build tasks target pools without `-alpha` variants, and bypassing the image filter meant they ran on every image-bump cron without actually validating the image.

## What's kept

- Gecko replication via `mozilla_taskgraph.transforms.replicate`
- `change_worker_pool_to_alpha` (with the pool-bound-scope rewrite from #780)
- `restore_gecko_revision_env` (the `*_REV` re-injection from #780)
- `IntegrationTestStrategy` image filter (unchanged)
- `find-successful-builds` filter job + `if: !cancelled() && needs.find-successful-builds.result == 'success'` gating (from #779, #784)

## Local verification

`taskgraph full -p taskcluster/test/params/cron-run-integration-tests.yml` now produces:

```
total tasks: 89
  gecko-prefixed: 88
  translations-prefixed: 0
```

vs the 253 (88 gecko + 164 translations) we had with translations enabled.

## Test plan

- [ ] Re-run `gcp-fxci-parallel-alpha.yml`. Confirm no `translations-*` tasks appear in any os-integration task group.
- [ ] Confirm gecko replication still works for the Linux Wayland 24.04 image.