### PR TITLE
linux: add Wayland input tools to Wayland image

### DIFF
--- a/scripts/linux/ubuntu-2404-amd64-gui/fxci/additional-packages.sh
+++ b/scripts/linux/ubuntu-2404-amd64-gui/fxci/additional-packages.sh
@@ -35,6 +35,10 @@ MISC_PACKAGES+=(python3-pip python3-certifi python3-psutil)
 # PyAutoGUI imports MouseInfo on Linux, which requires tkinter. Keep
 # python3-dev available for packages that still need native extension headers.
 MISC_PACKAGES+=(python3-tk python3-dev)
+# Xlib events are not respected by Wayland even with Xwayland, so DTE tests
+# drive input through Wayland directly. wtype handles keystrokes, xdotool
+# covers the Xwayland path, and wayland-utils ships diagnostic helpers.
+MISC_PACKAGES+=(wtype wayland-utils xdotool)
 # zstd packages
 MISC_PACKAGES+=(zstd python3-zstd)
 # install zstandard to avoid installing via pip and breaking via PEP 668 https://peps.python.org/pep-0668/


### PR DESCRIPTION
## Summary
Add `wtype`, `wayland-utils`, and `xdotool` to the Ubuntu 24.04 GUI/Wayland package list. Keeps the `python3-tk` / `python3-dev` deps from #773 in place — PyAutoGUI's CV functionality is still wanted.

## Context
Follow-up to #773, which got PyAutoGUI loading on `t-linux2404-wayland`. Since then DTE found Xlib events are not honoured under Wayland even with Xwayland active, so the tests need to drive Wayland directly: `wtype` for keystrokes, `xdotool` to keep the Xwayland route available, `wayland-utils` for diagnostics.

Tracked in [RELOPS-2358](https://mozilla-hub.atlassian.net/browse/RELOPS-2358).

## Testing
- `bash -n scripts/linux/ubuntu-2404-amd64-gui/fxci/additional-packages.sh`
- `git diff --check`

Image not built locally.