### PR TITLE
chore(azure): bump windows 1.3.4 and win11 25h2 1.0.4 image versions

### DIFF
--- a/config/trusted-win11-a64-24h2-builder.yaml
+++ b/config/trusted-win11-a64-24h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "trusted_win11_a64_24h2_builder"
   image_name: "trusted_win11_a64_24h2_builder"
-  image_version: "1.3.3"
+  image_version: "1.3.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/trusted-win11-a64-25h2-builder.yaml
+++ b/config/trusted-win11-a64-25h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "trusted_win11_a64_25h2_builder"
   image_name: "trusted_win11_a64_25h2_builder"
-  image_version: "1.0.3"
+  image_version: "1.0.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/trusted-win2022-64-2009.yaml
+++ b/config/trusted-win2022-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "trusted_win2022_64_2009"
   image_name: "trusted_win2022_64_2009"
-  image_version: "1.3.3"
+  image_version: "1.3.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win10-64-2009.yaml
+++ b/config/win10-64-2009.yaml
@@ -22,7 +22,7 @@ vm:
     sourceOrganization: "default"
     sourceRepository: "default"
     sourceBranch: "default"
-    deploymentId: "757b34d"
+    deploymentId: "default"
     managed_by: "default"
 tests:
   - microsoft_vcc_win10_win11_x64.tests.ps1

--- a/config/win10-64-2009.yaml
+++ b/config/win10-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win10_64_2009"
   image_name: "win10_64_2009"
-  image_version: "1.3.3"
+  image_version: "1.3.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"
@@ -22,7 +22,7 @@ vm:
     sourceOrganization: "default"
     sourceRepository: "default"
     sourceBranch: "default"
-    deploymentId: "71b0588"
+    deploymentId: "757b34d"
     managed_by: "default"
 tests:
   - microsoft_vcc_win10_win11_x64.tests.ps1

--- a/config/win11-64-24h2.yaml
+++ b/config/win11-64-24h2.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_64_24h2"
   image_name: "win11_64_24h2"
-  image_version: "1.3.3"
+  image_version: "1.3.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-64-25h2.yaml
+++ b/config/win11-64-25h2.yaml
@@ -37,7 +37,7 @@ vm:
     sourceOrganization: "default"
     sourceRepository: "default"
     sourceBranch: "default"
-    deploymentId: "757b34d"
+    deploymentId: "default"
     managed_by: "default"
 tests:
   - win11_sdk_tests.ps1

--- a/config/win11-64-25h2.yaml
+++ b/config/win11-64-25h2.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_64_25h2"
   image_name: "win11_64_25h2"
-  image_version: "1.0.3"
+  image_version: "1.0.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"
@@ -37,7 +37,7 @@ vm:
     sourceOrganization: "default"
     sourceRepository: "default"
     sourceBranch: "default"
-    deploymentId: "71b0588"
+    deploymentId: "757b34d"
     managed_by: "default"
 tests:
   - win11_sdk_tests.ps1

--- a/config/win11-a64-24h2-builder.yaml
+++ b/config/win11-a64-24h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_24h2_builder"
   image_name: "win11_a64_24h2_builder"
-  image_version: "1.3.3"
+  image_version: "1.3.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-a64-24h2-tester.yaml
+++ b/config/win11-a64-24h2-tester.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_24h2_tester"
   image_name: "win11_a64_24h2_tester"
-  image_version: "1.3.3"
+  image_version: "1.3.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-a64-25h2-builder.yaml
+++ b/config/win11-a64-25h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_25h2_builder"
   image_name: "win11_a64_25h2_builder"
-  image_version: "1.0.3"
+  image_version: "1.0.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-a64-25h2-tester.yaml
+++ b/config/win11-a64-25h2-tester.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_25h2_tester"
   image_name: "win11_a64_25h2_tester"
-  image_version: "1.0.3"
+  image_version: "1.0.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win2022-64-2009.yaml
+++ b/config/win2022-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win2022_64_2009"
   image_name: "win2022_64_2009"
-  image_version: "1.3.3"
+  image_version: "1.3.4"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/windows_production_defaults.yaml
+++ b/config/windows_production_defaults.yaml
@@ -11,7 +11,7 @@ vm:
     sourceRepository: ronin_puppet
     sourceBranch: master
     managed_by: packer
-    deploymentId: "71b0588"
+    deploymentId: "757b34d"
 images:
   production:
     - win10-64-2009


### PR DESCRIPTION
## Summary
- Bumps all production + trusted Windows configs to ronin_puppet `757b34d` (was `71b0588`).
- Untrusted + trusted 24H2 / Win10 / Win2022 family: `1.3.3 → 1.3.4`.
- Untrusted + trusted 25H2 family: `1.0.3 → 1.0.4`.

Only Windows-relevant commit in the range is the NVIDIA A10 GRID driver bump (RELOPS-2372).
The other production families are rolled forward for consistency; their provisioned content is unchanged.

## ronin_puppet commits in this bump

| sha | message |
| --- | --- |
| `919f6951a98d` | Install pyyaml on macOS M4 test workers (#1203) (#1204) — macOS only |
| `cc4253af20ad` | inventory: add macmini-m4-130 through 149 (#1205) — macOS only |
| `50bf30c1818d` | ci: drop ubuntu -backports from kitchen docker sources (#1212) — CI infra only |
| `757b34d34d03` | **RELOPS-2372: bump NVIDIA A10 GRID driver to 573.96 (vGPU 18.x) (#1218)** |

[Full compare](https://github.com/mozilla-platform-ops/ronin_puppet/compare/71b0588...757b34d)