### PR TITLE
chore(azure): pin build region for win11-a64-24h2-builder and trusted-25h2-builder

### DIFF
--- a/config/trusted-win11-a64-25h2-builder.yaml
+++ b/config/trusted-win11-a64-25h2-builder.yaml
@@ -11,10 +11,6 @@ sharedimage:
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"
-  # Pin build region away from centralus/eastus: 6 consecutive packer runs
-  # failed here at Exec[install_net_framework3.5] because DISM could not pull
-  # the NetFx3 SxS payload from the Microsoft Update CDN edge serving those
-  # regions. Other a64 builders that landed elsewhere succeeded.
   build_location: westus2
 vm:
   puppet_version: "default"

--- a/config/trusted-win11-a64-25h2-builder.yaml
+++ b/config/trusted-win11-a64-25h2-builder.yaml
@@ -11,6 +11,11 @@ sharedimage:
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"
+  # Pin build region away from centralus/eastus: 6 consecutive packer runs
+  # failed here at Exec[install_net_framework3.5] because DISM could not pull
+  # the NetFx3 SxS payload from the Microsoft Update CDN edge serving those
+  # regions. Other a64 builders that landed elsewhere succeeded.
+  build_location: westus2
 vm:
   puppet_version: "default"
   git_version: "default"

--- a/config/win11-a64-24h2-builder.yaml
+++ b/config/win11-a64-24h2-builder.yaml
@@ -11,10 +11,6 @@ sharedimage:
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"
-  # Pin build region away from centralus/eastus: 6 consecutive packer runs
-  # failed here at Exec[install_net_framework3.5] because DISM could not pull
-  # the NetFx3 SxS payload from the Microsoft Update CDN edge serving those
-  # regions. Other a64 builders that landed elsewhere succeeded.
   build_location: westus2
 vm:
   puppet_version: "default"

--- a/config/win11-a64-24h2-builder.yaml
+++ b/config/win11-a64-24h2-builder.yaml
@@ -11,6 +11,11 @@ sharedimage:
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"
+  # Pin build region away from centralus/eastus: 6 consecutive packer runs
+  # failed here at Exec[install_net_framework3.5] because DISM could not pull
+  # the NetFx3 SxS payload from the Microsoft Update CDN edge serving those
+  # regions. Other a64 builders that landed elsewhere succeeded.
+  build_location: westus2
 vm:
   puppet_version: "default"
   git_version: "default"


### PR DESCRIPTION
## Summary

Pin Packer's `build_location` to `westus2` for two ARM64 builder configs that have failed six consecutive Packer runs in `FXCI - Azure Prod Parallel Images`:

- `config/win11-a64-24h2-builder.yaml`
- `config/trusted-win11-a64-25h2-builder.yaml`

## What is failing

Both configs fail at puppet's `Exec[install_net_framework3.5]`. `Enable-WindowsOptionalFeature -Online -FeatureName NetFx3 -All` exits non-zero. The base ARM64 image arrives with NetFx3 in the `DisabledWithPayloadRemoved` state and DISM cannot fetch the SxS payload from Windows Update during the build.

Failed run: https://github.com/mozilla-platform-ops/worker-images/actions/runs/26192331696

## Why region

The other 9 configs in the same parallel run succeeded, including the other two ARM64 builders:

- `win11-a64-25h2-builder` (attempt 1)
- `trusted-win11-a64-24h2-builder` (attempt 3)

Without an explicit `azure.build_location`, `New-AzSharedWorkerImage` falls back to `Central US` (confirmed in `bin/WorkerImages/Public/New-AzSharedWorkerImage.ps1`). `az vm list` shows trusted Packer VMs land in `centralus`; untrusted prod workers live in `eastus`. The successful sibling ARM64 builders presumably landed on healthier (region x OS-SKU) pairs.

Hypothesis: specific Microsoft Update CDN edges that serve `centralus` and `eastus` are missing or serving-broken NetFx3 ARM64 payloads, and these two configs always land on those edges. Swapping to `westus2` hits different edges. `Standard_E8pds_v5` is available in `westus2` with no restrictions in both the trusted and untrusted FXCI subscriptions.

## Scope

This is a test, not a permanent fix.

- If the next parallel build for these two configs succeeds, we keep the pin.
- If it does not, we move on to the offline-cab fix in puppet (ship the NetFx3 SxS payload with the image and feed `DISM /Source:`).

No other configs are touched. `windows_production_defaults.yaml` is untouched.

## Test plan

- [ ] Trigger `sig-FXCI-parallel-build.yml` after merge and confirm both configs reach the Pester test stage (i.e. clear the puppet NetFx3 step).
- [ ] If they pass, leave the pin in place for at least one more production cycle to confirm it's not a one-off.
- [ ] If they still fail at NetFx3, revert this PR and switch to the offline-cab approach.