### PR TITLE
RELOPS-2396: move 20 nodes into win11-64-24h2-hw-perf-debug for PSU swap

### DIFF
--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -56,26 +56,17 @@ pools:
     secret_date: "01-20-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
-    - nuc13-024
     - nuc13-035
-    - nuc13-036
     - nuc13-045
-    - nuc13-059
     - nuc13-060
-    - nuc13-061
     - nuc13-068
-    - nuc13-070
     - nuc13-075
-    - nuc13-096
     - nuc13-124
-    - nuc13-130
     - nuc13-132
-    - nuc13-149
     - nuc13-150
-    - nuc13-154
     - nuc13-155
-    - nuc13-156
     - nuc13-157
+  # First 20 nodes to swap out PSUs and be tested: 10 down/assumed-PSU-failure nodes from relops1213 and 10 poorly-performing nodes from alpha.
   - name: "win11-64-24h2-hw-perf-debug"
     puppet_version: "8.10.0"
     openvox_version: "8.19.2"
@@ -89,7 +80,26 @@ pools:
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
-    - nuc13-902 # temp fake node — placeholder to prevent scripting failures on empty pool
+    - nuc13-001
+    - nuc13-024
+    - nuc13-029
+    - nuc13-036
+    - nuc13-044
+    - nuc13-059
+    - nuc13-061
+    - nuc13-062
+    - nuc13-070
+    - nuc13-074
+    - nuc13-085
+    - nuc13-096
+    - nuc13-105
+    - nuc13-119
+    - nuc13-130
+    - nuc13-137
+    - nuc13-144
+    - nuc13-149
+    - nuc13-154
+    - nuc13-156
   # Questionable nodes — CPU suppression confirmed or notable floor events detected in stress testing.
   # Not cleared for high-priority CPU-intensive work. Pending PSU inspection/replacement.
   - name: "win11-64-24h2-hw-alpha"
@@ -106,14 +116,12 @@ pools:
     secret_date: "02-06-2026"
     domain_suffix: "wintest2.releng.mdc1.mozilla.com"
     nodes:
-    - nuc13-001
     - nuc13-019
     - nuc13-020
     - nuc13-022
     - nuc13-023
     - nuc13-025
     - nuc13-028
-    - nuc13-029
     - nuc13-030
     - nuc13-031
     - nuc13-034
@@ -121,14 +129,12 @@ pools:
     - nuc13-039
     - nuc13-042
     - nuc13-043
-    - nuc13-044
     - nuc13-050
     - nuc13-051
     - nuc13-052
     - nuc13-053
     - nuc13-055
     - nuc13-058
-    - nuc13-062
     - nuc13-063
     - nuc13-065
     - nuc13-067
@@ -136,14 +142,12 @@ pools:
     - nuc13-071
     - nuc13-072
     - nuc13-073
-    - nuc13-074
     - nuc13-076
     - nuc13-077
     - nuc13-078
     - nuc13-079
     - nuc13-080
     - nuc13-084
-    - nuc13-085
     - nuc13-087
     - nuc13-092
     - nuc13-094
@@ -151,14 +155,12 @@ pools:
     - nuc13-099
     - nuc13-102
     - nuc13-103
-    - nuc13-105
     - nuc13-106
     - nuc13-111
     - nuc13-114
     - nuc13-115
     - nuc13-116
     - nuc13-117
-    - nuc13-119
     - nuc13-120
     - nuc13-122
     - nuc13-125
@@ -166,14 +168,12 @@ pools:
     - nuc13-131
     - nuc13-133
     - nuc13-134
-    - nuc13-137
     - nuc13-138
     - nuc13-139
     - nuc13-140
     - nuc13-141
     - nuc13-142
     - nuc13-143
-    - nuc13-144
     - nuc13-146
     - nuc13-147
     - nuc13-148


### PR DESCRIPTION
## Summary
Moves the first **20 NUC13 nodes** into the `win11-64-24h2-hw-perf-debug` pool ahead of a PSU swap-out and benchmarking/testing pass.

- Removed **10 down / assumed-PSU-failure** nodes from `win11-64-24h2-hw-relops1213`: nuc13-024, 036, 059, 061, 070, 096, 130, 149, 154, 156
- Removed **10 poorly-performing** nodes from `win11-64-24h2-hw-alpha`: nuc13-001, 029, 044, 062, 074, 085, 105, 119, 137, 144
- Added all 20 to `win11-64-24h2-hw-perf-debug` and removed the `nuc13-902` placeholder
- Updated the comment above the pool to note these are the first 20 to swap out PSUs and be tested

Nodes were selected to spread across the node-number range (≈ physical location).

Pool node counts after this change: relops1213 20→10, alpha 75→65, perf-debug 1(placeholder)→20.

## Tracking
- Coordination / test / benchmark: RELOPS-2396
- PSU swap-out request (IO): IO-3797

🤖 Generated with [Claude Code](https://claude.com/claude-code)