### PR TITLE
Bump trusted ubuntu 24.04 images to generic-worker v100.3.0

### DIFF
--- a/config/trusted-gw-fxci-gcp-l3-2404-arm64-headless-alpha.yaml
+++ b/config/trusted-gw-fxci-gcp-l3-2404-arm64-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-central1-a
 vm:
   disk_size: 60
-  taskcluster_version: 99.2.1
+  taskcluster_version: 100.3.0
   tc_arch: ARM64
   script_paths:
   - "scripts/linux/ubuntu-2404-headless-arm64-headless"

--- a/config/trusted-gw-fxci-gcp-l3-2404-headless-alpha.yaml
+++ b/config/trusted-gw-fxci-gcp-l3-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 99.2.1
+  taskcluster_version: 100.3.0
   tc_arch: AMD64
   script_paths:
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
Bumps the trusted (level 3) ubuntu 24.04 GCP image configs from generic-worker v99.2.1 to v100.3.0, matching #796 which bumped the level 1 (untrusted) ubuntu 24.04 images.

Affected configs:
- `config/trusted-gw-fxci-gcp-l3-2404-headless-alpha.yaml`
- `config/trusted-gw-fxci-gcp-l3-2404-arm64-headless-alpha.yaml`