### PR TITLE
RELOPS-1606: build TCEng Azure fuzzing images in FXCI

### DIFF
--- a/.github/workflows/nonsig-tceng-azure.yml
+++ b/.github/workflows/nonsig-tceng-azure.yml
@@ -64,6 +64,9 @@ jobs:
           Set-AzWorkerImageLocation @Vars
     outputs:
       LOCATIONS: ${{ steps.set-matrix.outputs.LOCATIONS }}
+      CLIENT_ID_SECRET: ${{ steps.set-matrix.outputs.CLIENT_ID_SECRET }}
+      SUBSCRIPTION_ID_SECRET: ${{ steps.set-matrix.outputs.SUBSCRIPTION_ID_SECRET }}
+      APPLICATION_ID_SECRET: ${{ steps.set-matrix.outputs.APPLICATION_ID_SECRET }}
 
   packer:
     needs: config
@@ -82,9 +85,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID_TCENG }}
+          client-id: ${{ secrets[needs.config.outputs.CLIENT_ID_SECRET] }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_TCENG }}
+          subscription-id: ${{ secrets[needs.config.outputs.SUBSCRIPTION_ID_SECRET] }}
           enable-AzPSSession: true
 
       - name: "Remove current images"
@@ -107,11 +110,11 @@ jobs:
             team               = "tceng"
             Location           = "${{ matrix.LOCATIONS }}"
             Key                = '${{ github.event.inputs.config }}'
-            Client_ID          = "${{ secrets.AZURE_CLIENT_ID_TCENG }}"
+            Client_ID          = "${{ secrets[needs.config.outputs.CLIENT_ID_SECRET] }}"
             oidc_request_url   = $env:ACTIONS_ID_TOKEN_REQUEST_URL
             oidc_request_token = $env:ACTIONS_ID_TOKEN_REQUEST_TOKEN
-            Subscription_ID    = "${{ secrets.AZURE_SUBSCRIPTION_ID_TCENG }}"
+            Subscription_ID    = "${{ secrets[needs.config.outputs.SUBSCRIPTION_ID_SECRET] }}"
             Tenant_ID          = "${{ secrets.AZURE_TENANT_ID }}"
-            Application_ID     = "${{ secrets.AZURE_APPLICATION_ID_TCENG }}"
+            Application_ID     = "${{ secrets[needs.config.outputs.APPLICATION_ID_SECRET] }}"
           }
           New-AzWorkerImage @Vars

--- a/bin/WorkerImages/Public/New-AzWorkerImage.ps1
+++ b/bin/WorkerImages/Public/New-AzWorkerImage.ps1
@@ -107,7 +107,11 @@ function New-AzWorkerImage {
     $ENV:PKR_VAR_oidc_request_token = $oidc_request_token
 
     if ($Team -eq "tceng" -and $ENV:PKR_VAR_uuid) {
-        $ENV:PKR_VAR_managed_image_name = "imageset-$($ENV:PKR_VAR_uuid)-$Location"
+        $managedImageName = "imageset-$($ENV:PKR_VAR_uuid)-$Location"
+        if ($YAML.azure["managed_image_name_suffix"]) {
+            $managedImageName = "$managedImageName-$($YAML.azure["managed_image_name_suffix"])"
+        }
+        $ENV:PKR_VAR_managed_image_name = $managedImageName
     }
     else {
         switch -Wildcard ($Key) {

--- a/bin/WorkerImages/Public/Set-AzWorkerImageLocation.ps1
+++ b/bin/WorkerImages/Public/Set-AzWorkerImageLocation.ps1
@@ -29,5 +29,27 @@ function Set-AzWorkerImageLocation {
         $locations = ($YAML.azure.locations | ConvertTo-Json -Compress)
     }
 
+    $subscription = $YAML.azure["subscription"]
+    switch ($subscription) {
+        { [string]::IsNullOrEmpty($_) -or $_ -eq "tceng" } {
+            $clientIdSecret = "AZURE_CLIENT_ID_TCENG"
+            $subscriptionIdSecret = "AZURE_SUBSCRIPTION_ID_TCENG"
+            $applicationIdSecret = "AZURE_APPLICATION_ID_TCENG"
+            break
+        }
+        { $_ -eq "fxci-untrusted" -or $_ -eq "azure2" } {
+            $clientIdSecret = "AZURE_CLIENT_ID_FXCI"
+            $subscriptionIdSecret = "AZURE_SUBSCRIPTION_ID_UNTRUSTED"
+            $applicationIdSecret = "AZURE_APPLICATION_ID_FXCI"
+            break
+        }
+        default {
+            throw "Unsupported Azure subscription '$subscription' in $YamlPath"
+        }
+    }
+
     Write-Output "LOCATIONS=$locations" >> $ENV:GITHUB_OUTPUT
+    Write-Output "CLIENT_ID_SECRET=$clientIdSecret" >> $ENV:GITHUB_OUTPUT
+    Write-Output "SUBSCRIPTION_ID_SECRET=$subscriptionIdSecret" >> $ENV:GITHUB_OUTPUT
+    Write-Output "APPLICATION_ID_SECRET=$applicationIdSecret" >> $ENV:GITHUB_OUTPUT
 }

--- a/config/tceng/README.md
+++ b/config/tceng/README.md
@@ -85,10 +85,12 @@ image:
   version: latest                        # Use latest published version
 
 azure:
+  subscription: tceng                         # Optional; defaults to tceng if omitted
   locations:                             # Azure regions to replicate the image to
     - centralus
     - eastus
   managed_image_resource_group_name: "rg-tc-eng-images"   # Destination image resource group
+  # managed_image_name_suffix: fuzzing    # Optional; only needed when consumers expect a suffix
   managed_image_storage_account_type: "Standard_LRS"      # Type of storage for managed image
 
 vm:
@@ -110,6 +112,16 @@ To test or work on new image builds that are **not explicitly listed in the work
 This config allows for temporary or experimental image builds without requiring updates to the workflow’s `config` input options.
 
 You can manually run the workflow and supply `"image_development"` as the build key to use this file.
+
+---
+
+## Azure Subscription Selection
+
+TCEng Azure configs default to the TCEng Azure subscription when `azure.subscription` is omitted or set to `tceng`.
+
+Use `azure.subscription: fxci-untrusted` for images that must be consumed by the `azure2` provider in `fxci-config`. Those images are built with the FXCI untrusted Azure credentials, and the destination resource group should be one that exists in that subscription, such as `rg-packer-worker-images`.
+
+If `fxci-config` references the image with `version: NA` and a `deployment_id`, set `azure.managed_image_name_suffix` to the same deployment ID. The TCEng Azure build uses UUID-based managed image names, and the suffix keeps the final Azure image name aligned with what `fxci-config` generates.
 
 ---
 

--- a/config/tceng/generic-worker-win2022-gpu.yaml
+++ b/config/tceng/generic-worker-win2022-gpu.yaml
@@ -5,12 +5,11 @@ image:
   sku: 2022-datacenter-azure-edition
   version: latest
 azure:
+  subscription: fxci-untrusted
   locations:
-    - eastus
-    - eastus2
-    - southcentralus
     - westus2
-  managed_image_resource_group_name: "rg-tc-eng-images"
+  managed_image_resource_group_name: "rg-packer-worker-images"
+  managed_image_name_suffix: fuzzing
   managed_image_storage_account_type: "Standard_LRS"
 vm:
   providerType: "azure"

--- a/config/tceng/generic-worker-win2022.yaml
+++ b/config/tceng/generic-worker-win2022.yaml
@@ -5,10 +5,12 @@ image:
   sku: 2022-datacenter-azure-edition
   version: latest
 azure:
+  subscription: fxci-untrusted
   locations:
     - centralus
     - eastus
-  managed_image_resource_group_name: "rg-tc-eng-images"
+  managed_image_resource_group_name: "rg-packer-worker-images"
+  managed_image_name_suffix: fuzzing
   managed_image_storage_account_type: "Standard_LRS"
 vm:
   providerType: "azure"


### PR DESCRIPTION
## Summary

For [RELOPS-1606](https://mozilla-hub.atlassian.net/browse/RELOPS-1606), make the TCEng Azure image workflow able to build images in the FXCI untrusted Azure subscription so they can be consumed by the `azure2` provider in `fxci-config`.

This changes the TCEng Azure workflow to select Azure credential secrets from the image YAML:

- default / `tceng` uses the existing TCEng Azure secrets
- `fxci-untrusted` / `azure2` uses the FXCI untrusted Azure secrets

The production `generic-worker-win2022` and `generic-worker-win2022-gpu` configs now opt into `fxci-untrusted`, build into `rg-packer-worker-images`, and append the `fuzzing` suffix to UUID-based managed image names. That produces names shaped like `imageset-<uuid>-centralus-fuzzing`, matching the `fxci-config` `version: NA` + `deployment_id: fuzzing` image lookup.

The GPU config is scoped to `westus2`, matching the current fuzzing GPU Azure pool location in `fxci-config` PR #899.

## Validation

- `actionlint .github/workflows/nonsig-tceng-azure.yml`
- `pre-commit run --files .github/workflows/nonsig-tceng-azure.yml bin/WorkerImages/Public/New-AzWorkerImage.ps1 bin/WorkerImages/Public/Set-AzWorkerImageLocation.ps1 config/tceng/README.md config/tceng/generic-worker-win2022.yaml config/tceng/generic-worker-win2022-gpu.yaml`
- `git diff --check`
- Verified `Set-AzWorkerImageLocation` outputs FXCI untrusted secrets for `generic-worker-win2022` and TCEng secrets for `generic-worker-win2022-staging`.
- Dry-ran `New-AzWorkerImage` with a mocked `packer` command and confirmed `generic-worker-win2022` generates `imageset-<uuid>-centralus-fuzzing` in `rg-packer-worker-images`.

## Follow-up

After the workflow builds the Azure images, `fxci-config` PR #899 should be updated with the generated per-location image names and `resource_group: rg-packer-worker-images` for the fuzzing Azure image entries.
