### PR TITLE
RELOPS-1606: allow AWS image builds in relops-aws-prod

### DIFF
--- a/.github/workflows/aws-tceng.yml
+++ b/.github/workflows/aws-tceng.yml
@@ -10,13 +10,32 @@ on:
         options:
           - generic-worker-ubuntu-24-04
           - generic-worker-ubuntu-24-04-arm64
+          - generic-worker-ubuntu-24-04-staging
+      aws_account:
+        type: choice
+        description: Choose which AWS account to build in
+        default: community-tc-workers
+        options:
+          - community-tc-workers
+          - relops-aws-prod
+      region:
+        type: choice
+        description: Choose the AWS region to build in
+        default: us-west-2
+        options:
+          - us-west-2
+          - us-east-1
+          - us-east-2
+          - us-west-1
+          - eu-west-1
 
 permissions:
   id-token: write
   contents: read
 
 env:
-  AWS_ROLE_ARN: arn:aws:iam::885316786408:role/GitHubActionsRole
+  COMMUNITY_TC_WORKERS_AWS_ROLE_ARN: arn:aws:iam::885316786408:role/GitHubActionsRole
+  RELOPS_AWS_PROD_ROLE_ARN: arn:aws:iam::961225894672:role/GitHubActionsRole
 
 jobs:
   check-access:
@@ -51,11 +70,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
+      - name: Select AWS role
+        id: aws-role
+        shell: bash
+        run: |
+          case "${{ github.event.inputs.aws_account }}" in
+            community-tc-workers)
+              echo "role-arn=${COMMUNITY_TC_WORKERS_AWS_ROLE_ARN}" >> "${GITHUB_OUTPUT}"
+              ;;
+            relops-aws-prod)
+              echo "role-arn=${RELOPS_AWS_PROD_ROLE_ARN}" >> "${GITHUB_OUTPUT}"
+              ;;
+            *)
+              echo "Unsupported AWS account: ${{ github.event.inputs.aws_account }}" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b
         with:
-          role-to-assume: ${{ env.AWS_ROLE_ARN }}
-          aws-region: us-west-2
+          role-to-assume: ${{ steps.aws-role.outputs.role-arn }}
+          aws-region: ${{ github.event.inputs.region }}
           role-session-name: github-actions-packer-build
 
       - name: Setup Packer
@@ -67,7 +103,7 @@ jobs:
           Import-Module "${{ github.workspace }}/bin/WorkerImages/WorkerImages.psm1"
           $Vars = @{
             Key     = '${{ github.event.inputs.config }}'
-            Region  = 'us-west-2'
+            Region  = '${{ github.event.inputs.region }}'
           }
 
           New-AWSWorkerImage @Vars

--- a/config/tceng/README.md
+++ b/config/tceng/README.md
@@ -73,6 +73,24 @@ The following files and directories are shared infrastructure and require a **PR
 
 ---
 
+## AWS Account Selection
+
+The TCEng AWS workflow can build AMIs in either the community worker account or
+the RelOps AWS production account:
+
+- `community-tc-workers`: `arn:aws:iam::885316786408:role/GitHubActionsRole`
+- `relops-aws-prod`: `arn:aws:iam::961225894672:role/GitHubActionsRole`
+
+For RELOPS-1606 fuzzing migration builds, run the AWS workflow with:
+
+```text
+config: generic-worker-ubuntu-24-04-staging
+aws_account: relops-aws-prod
+region: us-east-1
+```
+
+---
+
 ## 🧾 YAML Structure
 
 Each YAML file under `config/tceng/` defines an image and follows this structure:


### PR DESCRIPTION
## Summary
- add a TCEng AWS workflow account selector for the existing community worker account and relops-aws-prod
- use arn:aws:iam::961225894672:role/GitHubActionsRole when relops-aws-prod is selected
- expose generic-worker-ubuntu-24-04-staging and target region selection for RELOPS-1606 fuzzing builds

## RELOPS-1606 invocation
Use the manual TCEng AWS workflow with:

```text
config: generic-worker-ubuntu-24-04-staging
aws_account: relops-aws-prod
region: us-east-1
```

## Validation
- actionlint .github/workflows/aws-tceng.yml
- pre-commit run --files .github/workflows/aws-tceng.yml config/tceng/README.md
- git diff --check

Depends on the relops-aws-prod GitHub OIDC role:
- arn:aws:iam::961225894672:role/GitHubActionsRole
- arn:aws:iam::961225894672:oidc-provider/token.actions.githubusercontent.com