### PR TITLE
RELOPS-2427: build TCEng GCP fuzzing images in taskcluster-imaging

### DIFF
--- a/config/tceng/generic-worker-ubuntu-24-04-arm64.yaml
+++ b/config/tceng/generic-worker-ubuntu-24-04-arm64.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   # GCP-specific configuration
-  project_id: "community-tc-workers"
+  project_id: "taskcluster-imaging"
   zone: "us-central1-a"
   source_image_family: "ubuntu-2404-lts-arm64"
   image_name: "generic-worker-ubuntu-24-04-arm64"

--- a/config/tceng/generic-worker-ubuntu-24-04-staging.yaml
+++ b/config/tceng/generic-worker-ubuntu-24-04-staging.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  project_id: "community-tc-workers"
+  project_id: "taskcluster-imaging"
   zone: "us-central1-a"
   source_image_family: "ubuntu-2404-lts-amd64"
   image_name: "generic-worker-ubuntu-24-04-staging"

--- a/config/tceng/generic-worker-ubuntu-24-04.yaml
+++ b/config/tceng/generic-worker-ubuntu-24-04.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   # GCP-specific configuration
-  project_id: "community-tc-workers"
+  project_id: "taskcluster-imaging"
   zone: "us-central1-a"
   source_image_family: "ubuntu-2404-lts-amd64"
   image_name: "generic-worker-ubuntu-24-04"


### PR DESCRIPTION
## Summary

- change the TCEng GCP Ubuntu 24.04 fuzzing image configs to publish into `taskcluster-imaging` instead of `community-tc-workers`
- cover amd64, arm64, and staging TCEng configs used by the `TCEng GCP` workflow

## Context

fxci-config PR mozilla-releng/fxci-config#1042 currently points at the latest TCEng GCP outputs, but those outputs were created in `community-tc-workers`. For the fuzzing migration, the GCP images need to be rebuilt into `taskcluster-imaging` before fxci-config can stop referencing the community project.

## Validation

- `git diff --check`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `pre-commit run --files config/tceng/generic-worker-ubuntu-24-04.yaml config/tceng/generic-worker-ubuntu-24-04-arm64.yaml config/tceng/generic-worker-ubuntu-24-04-staging.yaml`

No image build workflows were triggered by this PR.