### PR TITLE
RELOPS-2427: build TCEng AWS images in Taskcluster account

### DIFF
--- a/.github/workflows/aws-tceng.yml
+++ b/.github/workflows/aws-tceng.yml
@@ -17,7 +17,7 @@ on:
         default: community-tc-workers
         options:
           - community-tc-workers
-          - relops-aws-prod
+          - taskcluster
       region:
         type: choice
         description: Choose the AWS region to build in
@@ -35,7 +35,7 @@ permissions:
 
 env:
   COMMUNITY_TC_WORKERS_AWS_ROLE_ARN: arn:aws:iam::885316786408:role/GitHubActionsRole
-  RELOPS_AWS_PROD_ROLE_ARN: arn:aws:iam::961225894672:role/GitHubActionsRole
+  TASKCLUSTER_AWS_ROLE_ARN: arn:aws:iam::692406183521:role/GitHubActionsRole
 
 jobs:
   check-access:
@@ -78,8 +78,8 @@ jobs:
             community-tc-workers)
               echo "role-arn=${COMMUNITY_TC_WORKERS_AWS_ROLE_ARN}" >> "${GITHUB_OUTPUT}"
               ;;
-            relops-aws-prod)
-              echo "role-arn=${RELOPS_AWS_PROD_ROLE_ARN}" >> "${GITHUB_OUTPUT}"
+            taskcluster)
+              echo "role-arn=${TASKCLUSTER_AWS_ROLE_ARN}" >> "${GITHUB_OUTPUT}"
               ;;
             *)
               echo "Unsupported AWS account: ${{ github.event.inputs.aws_account }}" >&2

--- a/config/tceng/README.md
+++ b/config/tceng/README.md
@@ -76,16 +76,16 @@ The following files and directories are shared infrastructure and require a **PR
 ## AWS Account Selection
 
 The TCEng AWS workflow can build AMIs in either the community worker account or
-the RelOps AWS production account:
+the Taskcluster AWS account:
 
 - `community-tc-workers`: `arn:aws:iam::885316786408:role/GitHubActionsRole`
-- `relops-aws-prod`: `arn:aws:iam::961225894672:role/GitHubActionsRole`
+- `taskcluster`: `arn:aws:iam::692406183521:role/GitHubActionsRole`
 
 For RELOPS-1606 fuzzing migration builds, run the AWS workflow with:
 
 ```text
 config: generic-worker-ubuntu-24-04-staging
-aws_account: relops-aws-prod
+aws_account: taskcluster
 region: us-east-1
 ```
 


### PR DESCRIPTION
## Summary
- replace the TCEng AWS workflow's relops-aws-prod option with the Taskcluster AWS account
- use arn:aws:iam::692406183521:role/GitHubActionsRole for Taskcluster AWS builds
- update the TCEng AWS README invocation to use aws_account: taskcluster

## Validation
- actionlint .github/workflows/aws-tceng.yml
- pre-commit run --files .github/workflows/aws-tceng.yml config/tceng/README.md
- git diff --check