### PR TITLE
RELOPS-2427: add fuzzing GPU Azure image regions

### DIFF
--- a/config/tceng/generic-worker-win2022-gpu.yaml
+++ b/config/tceng/generic-worker-win2022-gpu.yaml
@@ -7,6 +7,9 @@ image:
 azure:
   subscription: fxci-untrusted
   locations:
+    - eastus
+    - eastus2
+    - southcentralus
     - westus2
   managed_image_resource_group_name: "rg-packer-worker-images"
   managed_image_name_suffix: fuzzing


### PR DESCRIPTION
## Summary
- add eastus, eastus2, and southcentralus to the TCEng generic-worker-win2022-gpu image config
- keep westus2 so the image build covers the four GPU regions used by the fuzzing pools

## Verification
- Ran Set-AzWorkerImageLocation for tceng/generic-worker-win2022-gpu
- Matrix output: ["eastus","eastus2","southcentralus","westus2"]
- Credential selection output uses FXCI untrusted Azure secrets