### PR TITLE
RELOPS-2427: build fuzzing win2022 images with Taskcluster 90

### DIFF
--- a/config/tceng/generic-worker-win2022-gpu.yaml
+++ b/config/tceng/generic-worker-win2022-gpu.yaml
@@ -19,6 +19,6 @@ vm:
   vm_size: Standard_NV12s_v3
   bootstrapscript: "generic-worker-win2022"
   tc_arch: "amd64"
-  taskcluster_version: 100.0.1
+  taskcluster_version: 90.0.1
   tags:
     - image_set: markco-generic-worker-win2022-gpu-staging

--- a/config/tceng/generic-worker-win2022.yaml
+++ b/config/tceng/generic-worker-win2022.yaml
@@ -17,6 +17,6 @@ vm:
   vm_size: Standard_D2s_v3
   bootstrapscript: "generic-worker-win2022"
   tc_arch: "amd64"
-  taskcluster_version: 100.0.1
+  taskcluster_version: 90.0.1
   tags:
     - image_set: markco-generic-worker-win2022


### PR DESCRIPTION
## Summary\n- Pin TCEng generic-worker-win2022 and generic-worker-win2022-gpu builds to Taskcluster 90.0.1 to match community-tc-config's current fuzzing Windows images.\n\n## Testing\n- Verified generic-worker-win2022-gpu still expands to eastus, eastus2, southcentralus, and westus2 via Set-AzWorkerImageLocation.\n- Build workflows dispatched from this branch: win2022 run 27707909477, win2022-gpu run 27707909416.