### PR TITLE
RELOPS-2427: bump fuzzing win2022 Taskcluster to 100.0.1

### DIFF
--- a/config/tceng/generic-worker-win2022-gpu.yaml
+++ b/config/tceng/generic-worker-win2022-gpu.yaml
@@ -19,6 +19,6 @@ vm:
   vm_size: Standard_NV12s_v3
   bootstrapscript: "generic-worker-win2022"
   tc_arch: "amd64"
-  taskcluster_version: 90.0.1
+  taskcluster_version: 100.0.1
   tags:
     - image_set: markco-generic-worker-win2022-gpu-staging

--- a/config/tceng/generic-worker-win2022.yaml
+++ b/config/tceng/generic-worker-win2022.yaml
@@ -17,6 +17,6 @@ vm:
   vm_size: Standard_D2s_v3
   bootstrapscript: "generic-worker-win2022"
   tc_arch: "amd64"
-  taskcluster_version: 90.0.1
+  taskcluster_version: 100.0.1
   tags:
     - image_set: markco-generic-worker-win2022


### PR DESCRIPTION
## Summary
- bump tceng win2022 fuzzing images from Taskcluster 90.0.1 to 100.0.1
- match the current Community TC fuzzing Windows image baseline
- pick up Generic Worker fixes for intermittent Windows LoadUserProfile ERROR_NOT_READY failures

## Validation
- ruby YAML parse for both updated configs
- git diff --check
- confirmed v100.0.1 release has the Windows amd64 generic-worker, start-worker, livelog, and taskcluster-proxy assets

Follow-up for FXCI fuzzing work after worker-images #804 and fxci-config PRs #1048, #1049, #1051, and #1052.