### PR TITLE
Bump trusted ubuntu 24.04 images to generic-worker v100.4.0

### DIFF
--- a/config/trusted-gw-fxci-gcp-l3-2404-arm64-headless-alpha.yaml
+++ b/config/trusted-gw-fxci-gcp-l3-2404-arm64-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-central1-a
 vm:
   disk_size: 60
-  taskcluster_version: 100.3.0
+  taskcluster_version: 100.4.0
   tc_arch: ARM64
   script_paths:
   - "scripts/linux/ubuntu-2404-headless-arm64-headless"

--- a/config/trusted-gw-fxci-gcp-l3-2404-headless-alpha.yaml
+++ b/config/trusted-gw-fxci-gcp-l3-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 100.3.0
+  taskcluster_version: 100.4.0
   tc_arch: AMD64
   script_paths:
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
Aiming to pick up the changes for [bug 2045069](https://bugzilla.mozilla.org/show_bug.cgi?id=2045069).

Trusted-image counterpart to #807.