### PR TITLE
Bump windows prod images to ronin_puppet bb8cdb7

### DIFF
--- a/config/trusted-win11-a64-25h2-builder.yaml
+++ b/config/trusted-win11-a64-25h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "trusted_win11_a64_25h2_builder"
   image_name: "trusted_win11_a64_25h2_builder"
-  image_version: "1.0.4"
+  image_version: "1.0.5"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/trusted-win2022-64-2009.yaml
+++ b/config/trusted-win2022-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "trusted_win2022_64_2009"
   image_name: "trusted_win2022_64_2009"
-  image_version: "1.3.4"
+  image_version: "1.3.5"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win10-64-2009-alpha.yaml
+++ b/config/win10-64-2009-alpha.yaml
@@ -25,8 +25,8 @@ vm:
     worker_pool_id: win10-64-2009
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
-    sourceBranch: "relops/remove-vac-azure-cloud-workers"
-    deploymentId: "NA"
+    sourceBranch: "master"
+    deploymentId: "default"
     managed_by: packer
 tests:
   - microsoft_vcc_win10_win11_x64.tests.ps1

--- a/config/win10-64-2009.yaml
+++ b/config/win10-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win10_64_2009"
   image_name: "win10_64_2009"
-  image_version: "1.3.4"
+  image_version: "1.3.5"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-64-24h2-alpha.yaml
+++ b/config/win11-64-24h2-alpha.yaml
@@ -29,7 +29,7 @@ vm:
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
     sourceBranch: "master"
-    deploymentId: "NA"
+    deploymentId: "default"
     managed_by: packer
 tests:
   - win11_sdk_tests.ps1

--- a/config/win11-64-24h2.yaml
+++ b/config/win11-64-24h2.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_64_24h2"
   image_name: "win11_64_24h2"
-  image_version: "1.3.4"
+  image_version: "1.3.5"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-64-25h2-alpha.yaml
+++ b/config/win11-64-25h2-alpha.yaml
@@ -28,8 +28,8 @@ vm:
     worker_pool_id: win11-64-25h2-alpha
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
-    sourceBranch: "relops/remove-vac-azure-cloud-workers"
-    deploymentId: "NA"
+    sourceBranch: "master"
+    deploymentId: "default"
     managed_by: packer
 tests:
   - win11_sdk_tests.ps1

--- a/config/win11-64-25h2.yaml
+++ b/config/win11-64-25h2.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_64_25h2"
   image_name: "win11_64_25h2"
-  image_version: "1.0.4"
+  image_version: "1.0.5"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-a64-25h2-builder-alpha.yaml
+++ b/config/win11-a64-25h2-builder-alpha.yaml
@@ -24,8 +24,8 @@ vm:
     worker_pool_id: win11-a64-25h2-builder-alpha
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
-    sourceBranch: "relops/remove-vac-azure-cloud-workers"
-    deploymentId: "NA"
+    sourceBranch: "master"
+    deploymentId: "default"
     managed_by: packer
 tests:
   - directx_sdk.tests.ps1

--- a/config/win11-a64-25h2-builder.yaml
+++ b/config/win11-a64-25h2-builder.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_25h2_builder"
   image_name: "win11_a64_25h2_builder"
-  image_version: "1.0.4"
+  image_version: "1.0.5"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win11-a64-25h2-tester-alpha.yaml
+++ b/config/win11-a64-25h2-tester-alpha.yaml
@@ -24,8 +24,8 @@ vm:
     worker_pool_id: win11-a64-25h2-tester
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
-    sourceBranch: "relops/remove-vac-azure-cloud-workers"
-    deploymentId: "NA"
+    sourceBranch: "master"
+    deploymentId: "default"
     managed_by: packer
 tests:
   - error_reporting.tests.ps1

--- a/config/win11-a64-25h2-tester.yaml
+++ b/config/win11-a64-25h2-tester.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win11_a64_25h2_tester"
   image_name: "win11_a64_25h2_tester"
-  image_version: "1.0.4"
+  image_version: "1.0.5"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/win2022-64-2009-alpha.yaml
+++ b/config/win2022-64-2009-alpha.yaml
@@ -22,8 +22,8 @@ vm:
     worker_pool_id: win2022-64-2009
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
-    sourceBranch: "relops/remove-vac-azure-cloud-workers"
-    deploymentId: "NA"
+    sourceBranch: "master"
+    deploymentId: "default"
     managed_by: packer
 tests:
   - netframework_core.tests.ps1

--- a/config/win2022-64-2009.yaml
+++ b/config/win2022-64-2009.yaml
@@ -7,7 +7,7 @@ image:
 sharedimage:
   gallery_name: "win2022_64_2009"
   image_name: "win2022_64_2009"
-  image_version: "1.3.4"
+  image_version: "1.3.5"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"

--- a/config/windows_production_defaults.yaml
+++ b/config/windows_production_defaults.yaml
@@ -11,7 +11,7 @@ vm:
     sourceRepository: ronin_puppet
     sourceBranch: master
     managed_by: packer
-    deploymentId: "757b34d"
+    deploymentId: "bb8cdb7"
 images:
   production:
     - win10-64-2009


### PR DESCRIPTION
## Summary
- Pin the production ronin_puppet `deploymentId` to `bb8cdb7` (current master HEAD), up from `757b34d`.
- Patch-bump `image_version` on all eight production Windows configs: `win10-64-2009`, `win11-64-24h2`, `win11-64-25h2`, `win11-a64-25h2-tester`, `win11-a64-25h2-builder`, `win2022-64-2009`, and the two trusted configs (`trusted-win11-a64-25h2-builder`, `trusted-win2022-64-2009`).
- Switch the alpha configs (`win10`, `win11-24h2`, `win11-25h2`, `a64 tester`, `a64 builder`, `win2022`) to `sourceBranch: master` and `deploymentId: default` so they validate the same `bb8cdb7` commit, replacing the `relops/remove-vac-azure-cloud-workers` branch they were tracking.

## Rollout
Alpha first: dispatch `FXCI - Azure Alpha Parallel Images`, confirm the in-build `OS Integration Tests` jobs pass, then dispatch `FXCI - Azure Prod Parallel Images`.

Note: `win11-a64-25h2-builder-alpha` is commented out of `images.alpha`, and the a64 builder and `win2022` configs are excluded from in-build os-integration; those validate via `/taskcluster integration` on the fxci-config bump PR.
