### PR TITLE
Update virtual_drivers test for VB-CABLE pack 45 (RELOPS-2437)

### DIFF
--- a/tests/win/virtual_drivers.tests.ps1
+++ b/tests/win/virtual_drivers.tests.ps1
@@ -1,19 +1,18 @@
-## CLEAN-UP Version should be in Hiera
-
-Describe "Virtual Audio Cable" {
-    BeforeDiscovery {
-        $Hiera = $Data.Hiera
-    }
-
+Describe "VB-CABLE Virtual Audio Device" {
     BeforeAll {
-        $Software = Get-InstalledSoftware | Where-Object {
-            $PSItem.DisplayName -like "Virtual Audio Cable*"
-        }
+        # ronin_puppet RELOPS-2437 (#1234) replaced Virtual Audio Cable 4.64
+        # with VB-CABLE pack 45, which registers as a system driver and a
+        # MEDIA PnP device rather than an entry in installed software.
+        $ServiceName = "VBAudioVACMME"
+        $DeviceName  = "VB-Audio Virtual Cable"
+        $Driver = Get-CimInstance Win32_SystemDriver -Filter "Name='$ServiceName'" -ErrorAction SilentlyContinue
+        $Device = Get-PnpDevice -Class MEDIA -ErrorAction SilentlyContinue |
+            Where-Object { $PSItem.FriendlyName -eq $DeviceName }
     }
-    It "Virtual Audio Cable is installed" {
-        $Software.DisplayName | Should -Not -Be $Null
+    It "VB-CABLE system driver ($ServiceName) is installed" {
+        $Driver | Should -Not -BeNullOrEmpty
     }
-    It "Virtual Audio Cable is version 4.64" {
-        $Software.DisplayVersion | Should -Be "4.64"
+    It "VB-Audio Virtual Cable MEDIA device is present" {
+        $Device | Should -Not -BeNullOrEmpty
     }
 }


### PR DESCRIPTION
## Summary
Update `tests/win/virtual_drivers.tests.ps1` to validate VB-CABLE pack 45 instead of Virtual Audio Cable 4.64.

ronin_puppet RELOPS-2437 (mozilla-platform-ops/ronin_puppet#1234) replaced Virtual Audio Cable 4.64 with VB-CABLE pack 45 on Azure Windows workers. VB-CABLE registers as a system driver and a MEDIA PnP device, not as an entry in installed software, so the old assertions (`DisplayName -like "Virtual Audio Cable*"`, version `4.64`) no longer match.

The test now checks the same things ronin_puppet's own serverspec checks for this package:
- the `VBAudioVACMME` system driver exists
- a MEDIA PnP device named `VB-Audio Virtual Cable` is present

## Why
After pinning production to ronin_puppet `bb8cdb7` (which includes #1234), the production builds of `win10-64-2009`, `win11-64-24h2`, and `win11-64-25h2` failed because this stale test reported 2 failures during the in-VM Pester run. The alpha configs already have this test commented out for the VAC-removal work, so the alpha builds did not surface it.

## Follow-ups (not in this PR)
- Re-enable `virtual_drivers.tests.ps1` in the alpha configs once VB-CABLE is confirmed on those images, so alpha catches audio-driver regressions again.
- `win2022-64-2009` fails for an unrelated reason (`HKLM:\SOFTWARE\Mozilla\ronin_puppet` missing during provisioning); tracked separately.
