### PR TITLE
Test RELOPS-2449: point a64 builder alpha at NetFx3-skip branch

### DIFF
--- a/config/win11-a64-25h2-builder-alpha.yaml
+++ b/config/win11-a64-25h2-builder-alpha.yaml
@@ -24,8 +24,8 @@ vm:
     worker_pool_id: win11-a64-25h2-builder-alpha
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
-    sourceBranch: "master"
-    deploymentId: "default"
+    sourceBranch: "relops-2449-skip-netfx3-arm64"
+    deploymentId: "NA"
     managed_by: packer
 tests:
   - directx_sdk.tests.ps1


### PR DESCRIPTION
## Summary
Point the `win11-a64-25h2-builder-alpha` config at the ronin_puppet branch `relops-2449-skip-netfx3-arm64` (`deploymentId: NA`) to validate the RELOPS-2449 fix that skips the flaky NetFx3 install on ARM64.

This is a temporary alpha-testing pointer. Once ronin_puppet PR #1244 merges to master, this config goes back to `sourceBranch: master` / `deploymentId: default`.

## Why this needs to be on main
Azure login uses OIDC federated identity that only trusts approved refs, so the alpha build must run from `main`; the config's `sourceBranch` is what targets the ronin feature branch at provisioning time. Dispatching the workflow from a side branch fails Azure login (`AADSTS700213`).

Related: RELOPS-2449, ronin_puppet#1244.
