### PR TITLE
Drop directx_sdk test from arm64 builders (DXSDK skipped on ARM64)

### DIFF
--- a/config/win11-a64-25h2-builder-alpha.yaml
+++ b/config/win11-a64-25h2-builder-alpha.yaml
@@ -28,7 +28,6 @@ vm:
     deploymentId: "NA"
     managed_by: packer
 tests:
-  - directx_sdk.tests.ps1
   - microsoft_binscope.tests.ps1
   - microsoft_vcc_2008_arm64.tests.ps1
   - microsoft_vcc_2010_arm64.tests.ps1

--- a/config/win11-a64-25h2-builder.yaml
+++ b/config/win11-a64-25h2-builder.yaml
@@ -25,7 +25,6 @@ vm:
     deploymentId: "default"
     managed_by: "default"
 tests:
-  - directx_sdk.tests.ps1
   - microsoft_binscope.tests.ps1
   - microsoft_vcc_2008_arm64.tests.ps1
   - microsoft_vcc_2010_arm64.tests.ps1


### PR DESCRIPTION
ronin_puppet RELOPS-2449 (#1244) skips both NetFx3 and DirectX SDK on ARM64 builders, so the arm64 builder images no longer install DXSDK. Remove `directx_sdk.tests.ps1` from `win11-a64-25h2-builder` and `win11-a64-25h2-builder-alpha` so the in-VM Pester run does not check for it. (NetFx3 has no active Pester check on these configs; the trusted a64 builder does not run the directx test.)