### PR TITLE
Drop VC++ 2008 test from arm64 builders

### DIFF
--- a/config/trusted-win11-a64-25h2-builder.yaml
+++ b/config/trusted-win11-a64-25h2-builder.yaml
@@ -27,7 +27,6 @@ vm:
     managed_by: "default"
 tests:
   - microsoft_binscope.tests.ps1
-  - microsoft_vcc_2008_arm64.tests.ps1
   - microsoft_vcc_2010_arm64.tests.ps1
   - microsoft_vcc_2015_arm64.tests.ps1
   - microsoft_vcc_2022_arm64.tests.ps1

--- a/config/win11-a64-25h2-builder-alpha.yaml
+++ b/config/win11-a64-25h2-builder-alpha.yaml
@@ -29,7 +29,6 @@ vm:
     managed_by: packer
 tests:
   - microsoft_binscope.tests.ps1
-  - microsoft_vcc_2008_arm64.tests.ps1
   - microsoft_vcc_2010_arm64.tests.ps1
   - microsoft_vcc_2015_arm64.tests.ps1
   - microsoft_vcc_2022_arm64.tests.ps1

--- a/config/win11-a64-25h2-builder.yaml
+++ b/config/win11-a64-25h2-builder.yaml
@@ -26,7 +26,6 @@ vm:
     managed_by: "default"
 tests:
   - microsoft_binscope.tests.ps1
-  - microsoft_vcc_2008_arm64.tests.ps1
   - microsoft_vcc_2010_arm64.tests.ps1
   - microsoft_vcc_2015_arm64.tests.ps1
   - microsoft_vcc_2022_arm64.tests.ps1


### PR DESCRIPTION
The Microsoft Visual C++ 2008 Redistributable (x86 9.0.30729) was only ever installed on the ARM64 builders as a side-effect of the DirectX SDK June 2010 installer. RELOPS-2449 (#1244) skips DXSDK on ARM64, so the 2008 redist is no longer present and `microsoft_vcc_2008_arm64.tests.ps1` fails. Nothing in the ARM64 builder toolchain needs the 2008 CRT (2010/2015/2022 redists still install and pass), so drop the test from the three a64 builder configs.