### PR TITLE
Retry packer builds up to 10 times on transient WinRM failures

### DIFF
--- a/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
+++ b/.github/workflows/sig-FXCI-nontrusted-parallel-build-alpha.yml
@@ -96,7 +96,20 @@ jobs:
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI }}"
           }
-          New-AzSharedWorkerImage @Vars
+          $maxAttempts = 10
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Packer attempt $attempt of $maxAttempts"
+            New-AzSharedWorkerImage @Vars
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              Write-Host "::error ::Packer failed after $maxAttempts attempts"
+              exit 1
+            }
+            Write-Host "::warning ::Packer failed (attempt $attempt, exit code $LASTEXITCODE). Retrying in 30 seconds..."
+            Start-Sleep -Seconds 30
+          }
           "sharedimageversion=$ENV:PKR_VAR_sharedimage_version" >> $env:GITHUB_ENV
       - name: Upload Release Notes Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/sig-nontrusted.yml
+++ b/.github/workflows/sig-nontrusted.yml
@@ -76,7 +76,20 @@ jobs:
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI }}"
           }
-          New-AzSharedWorkerImage @Vars
+          $maxAttempts = 10
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Packer attempt $attempt of $maxAttempts"
+            New-AzSharedWorkerImage @Vars
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              Write-Host "::error ::Packer failed after $maxAttempts attempts"
+              exit 1
+            }
+            Write-Host "::warning ::Packer failed (attempt $attempt, exit code $LASTEXITCODE). Retrying in 30 seconds..."
+            Start-Sleep -Seconds 30
+          }
           "sharedimageversion=$ENV:PKR_VAR_sharedimage_version" >> $env:GITHUB_ENV
       - name: Upload Release Notes Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/sig-trusted.yml
+++ b/.github/workflows/sig-trusted.yml
@@ -62,7 +62,20 @@ jobs:
             Tenant_ID = "${{ secrets.AZURE_TENANT_ID }}"
             Application_ID = "${{ secrets.AZURE_APPLICATION_ID_FXCI_TRUSTED }}"
           }
-          New-AzSharedWorkerImage @Vars
+          $maxAttempts = 10
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Packer attempt $attempt of $maxAttempts"
+            New-AzSharedWorkerImage @Vars
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              Write-Host "::error ::Packer failed after $maxAttempts attempts"
+              exit 1
+            }
+            Write-Host "::warning ::Packer failed (attempt $attempt, exit code $LASTEXITCODE). Retrying in 30 seconds..."
+            Start-Sleep -Seconds 30
+          }
           "sharedimageversion=$ENV:PKR_VAR_sharedimage_version" >> $env:GITHUB_ENV
       - name: Upload Release Notes Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a


### PR DESCRIPTION
## Summary
Packer builds intermittently fail on transient WinRM upload errors (`Couldn't create shell: received error response`, `Error removing temporary file ... received error response`), which fails the whole workflow before provisioning even starts.

Wrap the `New-AzSharedWorkerImage` call in a retry loop (up to **10 attempts**, 30s between) in the SIG build workflows. `$LASTEXITCODE` detects packer failure since `packer build` is a native command that does not throw.

Workflows updated:
- `sig-nontrusted.yml`
- `sig-trusted.yml`
- `sig-FXCI-nontrusted-parallel-build-alpha.yml`

## Notes
- Workaround for transient flakes, not a WinRM root-cause fix; a genuinely reproducible failure still fails after 10 attempts.
- Alpha builds use `packer build -force`, so retries overwrite cleanly. On the single-config prod paths there is no `-force`; in practice the WinRM flakes occur before any image is published, so retries are clean.

Supersedes #712 (rebased onto current main; the two now-removed workflows from that draft, `sig-monitor-nontrusted.yml` and `DEV-sig-nontrusted.yml`, are dropped).
