### PR TITLE
Preseed Gecko checkout cache on Windows ARM builders

### DIFF
--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -416,8 +416,12 @@ build {
   provisioner "powershell" {
     elevated_password = ""
     elevated_user     = "SYSTEM"
+    environment_vars = [
+      "worker_pool_id=${var.worker_pool_id}"
+    ]
     inline = [
       "Import-Module BootStrap -Force;",
+      "Get-MozillaUnified;",
       "Disable-Services"
     ]
   }

--- a/config/win11-a64-25h2-builder-alpha.yaml
+++ b/config/win11-a64-25h2-builder-alpha.yaml
@@ -45,6 +45,7 @@ tests:
   - scheduled_tasks.tests.ps1
   - azure_vm_agent.tests.ps1
   - mercurial.tests.ps1
+  - cache_vcs_checkout.tests.ps1
   - logging.tests.ps1
   - sevenzip.tests.ps1
   - google_auth.tests.ps1

--- a/config/win11-a64-25h2-builder.yaml
+++ b/config/win11-a64-25h2-builder.yaml
@@ -42,6 +42,7 @@ tests:
   - scheduled_tasks.tests.ps1
   - azure_vm_agent.tests.ps1
   - mercurial.tests.ps1
+  - cache_vcs_checkout.tests.ps1
   - logging.tests.ps1
   - sevenzip.tests.ps1
   - google_auth.tests.ps1

--- a/scripts/windows/CustomFunctions/Bootstrap/Public/Get-MozillaUnified.ps1
+++ b/scripts/windows/CustomFunctions/Bootstrap/Public/Get-MozillaUnified.ps1
@@ -2,7 +2,13 @@ function Get-MozillaUnified {
     [CmdletBinding()]
     param (
         [String]
-        $ClonePath = "C:\vcs-checkout",
+        $WorkerPoolId = $ENV:worker_pool_id,
+
+        [String]
+        $CacheRoot = "C:\worker-runner\caches",
+
+        [String]
+        $WorkerRunnerPath = "C:\worker-runner",
 
         [String]
         $Repository = "https://hg.mozilla.org/mozilla-unified",
@@ -11,92 +17,130 @@ function Get-MozillaUnified {
         $Hg = "C:\Program Files\Mercurial\hg.exe",
 
         [String]
-        $Branch = "autoland"
-    )
-    ## Let's capture both a string and boolean
-    if ($ENV:clone_mozilla_unified -match "false|False" -or $ENV:clone_mozilla_unified -eq $false) {
-        Write-Log -message "Skipping clone due to $ENV:clone_mozilla_unified" -severity 'INFO'
-        Write-Host ('{0} :: Skipping clone due to {1}' -f $($MyInvocation.MyCommand.Name), $ENV:clone_mozilla_unified)
-        exit 0
-    }
+        $Branch = "autoland",
 
-    ## Create directory and set permissions to everyone
-    if (-Not (Test-Path $ClonePath)) {
-        try {
-            New-Item -ItemType Directory -Path $ClonePath -Force | Out-Null
-            $acl = Get-Acl $ClonePath
+        [String]
+        $SparseProfile = "build/sparse-profiles/profile-generate"
+    )
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    Write-Log -message ('{0} :: begin - {1:o}' -f $($MyInvocation.MyCommand.Name), (Get-Date).ToUniversalTime()) -severity 'DEBUG'
+    Write-Host "========== $($MyInvocation.MyCommand.Name) started at $((Get-Date).ToUniversalTime().ToString('o')) =========="
+
+    try {
+        if ([String]::IsNullOrWhiteSpace($WorkerPoolId)) {
+            try {
+                $WorkerPoolId = Get-WorkerPoolId
+            }
+            catch {
+                $WorkerPoolId = ""
+            }
+        }
+
+        ## Let's capture both a string and boolean
+        if ($ENV:clone_mozilla_unified -match "false|False" -or $ENV:clone_mozilla_unified -eq $false) {
+            Write-Log -message "Skipping clone due to $ENV:clone_mozilla_unified" -severity 'INFO'
+            Write-Host ('{0} :: Skipping clone due to {1}' -f $($MyInvocation.MyCommand.Name), $ENV:clone_mozilla_unified)
+            return
+        }
+
+        if ($WorkerPoolId -notmatch '^win11-a64-25h2-builder(-alpha)?$') {
+            Write-Log -message "Skipping mozilla-unified cache for worker pool $WorkerPoolId" -severity 'INFO'
+            Write-Host ('{0} :: Skipping mozilla-unified cache for worker pool {1}' -f $($MyInvocation.MyCommand.Name), $WorkerPoolId)
+            return
+        }
+
+        $CacheName = "gecko-level-1-checkouts-sparse"
+        $CachePath = Join-Path $CacheRoot $CacheName
+        $ClonePath = Join-Path $CachePath "src"
+        $ShareBase = Join-Path $CachePath "hg-store"
+        $MetadataPath = Join-Path $WorkerRunnerPath "directory-caches.json"
+
+        if (-Not (Test-Path $Hg)) {
+            throw "Mercurial not found at $Hg"
+        }
+
+        if (-Not (Test-Path "C:\mozilla-build\robustcheckout.py")) {
+            throw "robustcheckout.py not found in C:\mozilla-build"
+        }
+
+        foreach ($Path in @($CacheRoot, $CachePath, $WorkerRunnerPath)) {
+            if (-Not (Test-Path $Path)) {
+                New-Item -ItemType Directory -Path $Path -Force | Out-Null
+            }
+
+            $acl = Get-Acl $Path
             $permission = "Everyone", "FullControl", "Allow"
             $rule = New-Object System.Security.AccessControl.FileSystemAccessRule $permission
             $acl.SetAccessRule($rule)
-            Set-Acl $ClonePath $acl
-            Write-Log -message "Successfully set permissions on $ClonePath" -severity 'INFO'
-        }
-        catch {
-            Write-Log -message "Failed to set permissions on $ClonePath`: $($_.Exception.Message)" -severity 'ERROR'
-            exit 2
-        }
-    }
-
-    Write-Log -message "Starting mozilla-unified clone to $ClonePath" -severity 'INFO'
-
-    try {
-        Write-Log -message "Cloning $Repository to $ClonePath" -severity 'INFO'
-
-        $TempClonePath = Join-Path $env:TEMP "hg-shared_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
-
-        ## Initialize the $clonePath
-        $initSplat = @{
-            FilePath = $Hg
-            ArgumentList = @(
-                "init",
-                $ClonePath
-            )
-            Wait = $true
-            PassThru = $true
-            NoNewWindow = $true
+            Set-Acl $Path $acl
+            Write-Log -message "Successfully set permissions on $Path" -severity 'INFO'
         }
 
-        $initProcess = Start-Process @initSplat
-
-        if ($initProcess.ExitCode -eq 0) {
-            Write-Log -message "Successfully initialized $ClonePath" -severity 'INFO'
-            exit 0
+        if ((Test-Path $ClonePath) -and (Test-Path $ShareBase)) {
+            Write-Log -message "Using existing mozilla-unified checkout cache at $CachePath" -severity 'INFO'
         }
         else {
-            Write-Log -message "Failed to initialize $ClonePath. Exit code: $($initProcess.ExitCode)" -severity 'ERROR'
-            exit 1
+            Write-Log -message "Starting mozilla-unified checkout cache at $CachePath" -severity 'INFO'
+
+            $Splat = @{
+                FilePath     = $Hg
+                ArgumentList = @(
+                    "robustcheckout",
+                    "--sharebase",
+                    $ShareBase,
+                    "--purge",
+                    "--config",
+                    "extensions.robustcheckout=C:\\mozilla-build\\robustcheckout.py",
+                    "--upstream",
+                    $Repository,
+                    "--sparseprofile",
+                    $SparseProfile,
+                    "--branch",
+                    $Branch,
+                    $Repository,
+                    $ClonePath
+                )
+                Wait         = $true
+                PassThru     = $true
+                NoNewWindow  = $true
+            }
+            $hgProcess = Start-Process @Splat
+
+            if ($hgProcess.ExitCode -ne 0) {
+                throw "Failed to cache mozilla-unified. Exit code: $($hgProcess.ExitCode)"
+            }
+
+            Write-Log -message "Successfully cached mozilla-unified at $CachePath" -severity 'INFO'
         }
 
-        $Splat = @{
-            FilePath     = $Hg
-            ArgumentList = @(
-                "robustcheckout",
-                "--sharebase",
-                $TempClonePath,
-                "--config",
-                "extensions.robustcheckout=C:\\mozilla-build\\robustcheckout.py",
-                "--branch",
-                $Branch,
-                $Repository,
-                $ClonePath
-            )
-            Wait         = $true
-            PassThru     = $true
-            NoNewWindow  = $true
-        }
-        $hgProcess = Start-Process @Splat
-
-        if ($hgProcess.ExitCode -eq 0) {
-            Write-Log -message "Successfully cloned mozilla-unified to $ClonePath" -severity 'INFO'
-            exit 0
-        }
-        else {
-            Write-Log -message "Failed to clone mozilla-unified. Exit code: $($hgProcess.ExitCode)" -severity 'ERROR'
-            exit 1
-        }
+        $timestamp = (Get-Date).ToUniversalTime().ToString("o")
+        $directoryCaches = [ordered]@{}
+        $directoryCaches[$CacheName] = @(
+            [ordered]@{
+                created   = $timestamp
+                location  = $CachePath
+                hits      = 0
+                key       = $CacheName
+                sha256    = ""
+                in_use    = $false
+                last_used = $timestamp
+            }
+        )
+        $json = $directoryCaches | ConvertTo-Json -Depth 5
+        $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($MetadataPath, "$json`n", $utf8NoBom)
+        Write-Log -message "Wrote generic-worker directory cache metadata to $MetadataPath" -severity 'INFO'
     }
     catch {
-        Write-Log -message "Error cloning mozilla-unified: $($_.Exception.Message)" -severity 'ERROR'
-        exit 6
+        Write-Log -message "Error caching mozilla-unified: $($_.Exception.Message)" -severity 'ERROR'
+        throw
+    }
+    finally {
+        $stopwatch.Stop()
+        $elapsedMinutes = [int][math]::Floor($stopwatch.Elapsed.TotalMinutes)
+        $elapsedSeconds = $stopwatch.Elapsed.Seconds
+        Write-Log -message ('{0} :: completed in {1} minutes, {2} seconds' -f $($MyInvocation.MyCommand.Name), $elapsedMinutes, $elapsedSeconds) -severity 'DEBUG'
+        Write-Host "========== $($MyInvocation.MyCommand.Name) completed in $elapsedMinutes minutes, $elapsedSeconds seconds =========="
     }
 }

--- a/tests/win/cache_vcs_checkout.tests.ps1
+++ b/tests/win/cache_vcs_checkout.tests.ps1
@@ -1,8 +1,34 @@
 Describe "Cache VCS Checkout" {
-    It "Mozilla Unified Directory" {
-        Test-Path "C:\vcs-checkout" | Should -Be True
+    BeforeAll {
+        $CacheName = "gecko-level-1-checkouts-sparse"
+        $CachePath = "C:\worker-runner\caches\$CacheName"
+        $MetadataPath = "C:\worker-runner\directory-caches.json"
     }
-    It "Mozilla Unified contains revision" {
-        (Get-ChildItem "C:\vcs-checkout\*").Name | Should -Not -BeNullOrEmpty
+
+    It "Mozilla Unified directory cache exists" {
+        Test-Path $CachePath | Should -Be $true
+    }
+
+    It "Mozilla Unified shared store exists" {
+        Test-Path (Join-Path $CachePath "hg-store") | Should -Be $true
+    }
+
+    It "Mozilla Unified sparse checkout exists" {
+        Test-Path (Join-Path $CachePath "src\.hg") | Should -Be $true
+    }
+
+    It "Generic Worker directory cache metadata exists" {
+        Test-Path $MetadataPath | Should -Be $true
+    }
+
+    It "Generic Worker can find the Mozilla Unified directory cache" {
+        $metadata = Get-Content $MetadataPath -Raw | ConvertFrom-Json
+        $cacheEntries = @($metadata.PSObject.Properties[$CacheName].Value)
+
+        $cacheEntries | Should -Not -BeNullOrEmpty
+        $cacheEntries[0].location | Should -Be $CachePath
+        $cacheEntries[0].key | Should -Be $CacheName
+        $cacheEntries[0].in_use | Should -Be $false
+        Test-Path $cacheEntries[0].location | Should -Be $true
     }
 }


### PR DESCRIPTION
## Summary

- preseed `gecko-level-1-checkouts-sparse` during the `win11-a64-25h2-builder` and `win11-a64-25h2-builder-alpha` image builds
- store the seeded checkout under `C:\worker-runner\caches` so it survives Azure image capture, then write `C:\worker-runner\directory-caches.json` in generic-worker's directory-cache state format
- add Pester coverage that verifies the Mercurial shared store, sparse checkout, and generic-worker cache metadata exist in the built image

The profile-server task mounts the writable cache at `build/`, so the seeded cache contains `src` and `hg-store` in the same layout that `run-task --gecko-checkout=build/src --gecko-sparse-profile=build/sparse-profiles/profile-generate` expects. Azure's `D:` temp disk is not captured into the managed image, so the image-time cache lives on the OS disk instead of `D:\caches`.

## Searchfox / Taskcluster notes

This intentionally pre-creates generic-worker cache state before generic-worker's first run. Generic-worker loads `directory-caches.json` during mounts initialization, acquires a matching cache entry by `cacheName`, and moves the existing directory into the task mount path. It does not need to have created the directory itself first.

Searchfox confirms the cache key is computed, not a literal in the profile task:

- `taskcluster/gecko_taskgraph/transforms/job/common.py`: `get_cache_name()` returns `checkouts-sparse` for hg tasks with a sparse profile, and `support_vcs_checkout()` installs that as the checkout cache-name helper.
- `taskcluster/gecko_taskgraph/transforms/task.py`: generic-worker payload generation prefixes mount cache names as `{trust_domain}-level-{level}-{name}`.

For this worker pool (`gecko-1/win11-a64-25h2-builder-alpha`) and hg sparse profile tasks, that produces `gecko-level-1-checkouts-sparse`, matching the target task payload. This PR does not try to cover level-3/trusted builders or non-sparse/git checkout cache names.

## Timing / history

The target task, `V9HeyYLSRoG65_Mv3j5mYw`, is still running, but its live log already shows a cold first-provision cache:

- `[mounts] No existing writable directory cache 'gecko-level-1-checkouts-sparse'`
- clone bundle progress against `6963601216` bytes, about 6.96 GB

I sampled the 50 most recent Treeherder similar jobs for job `574801572` and parsed their live logs. 38 cold-cache jobs had VCS perf data, and 3 warm-cache jobs had VCS perf data.

Cold first-provision checkout cost:

- clone: median 19.9m, min 19.0m, max 20.8m, p95 approx 20.4m
- VCS overall: median 21.9m, min 20.6m, max 23.7m, p95 approx 22.6m
- bundle size: median 6.95 GB

Warm directory-cache cost from the same history:

- VCS overall: median 2.2m, min 2.1m, max 2.4m

Example completed cold task: `Sf8sw2jMTN6k8Fehlk6T9Q` spent 19.9m in clone and 21.7m in VCS overall. The image build should pay roughly that cold checkout cost once per image build, then first-provisioned workers avoid the network clone before profileserver starts.

## Validation

- `pwsh` parser check for `Get-MozillaUnified.ps1` and `cache_vcs_checkout.tests.ps1`
- metadata JSON round-trip check for the generated generic-worker cache shape
- `packer fmt -check azure.pkr.hcl`
- `packer validate -syntax-only azure.pkr.hcl`
- `git diff --check`
- pre-commit hook on commit: trailing whitespace and Packer Format
- GitHub checks: `shellcheck`, `pre-commit`, `psscriptanalyzer`
