### PR TITLE
Pin windows production images to ronin_puppet 82415f4

### DIFF
--- a/config/win11-a64-25h2-builder-alpha.yaml
+++ b/config/win11-a64-25h2-builder-alpha.yaml
@@ -24,8 +24,8 @@ vm:
     worker_pool_id: win11-a64-25h2-builder-alpha
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
-    sourceBranch: "relops-2449-skip-netfx3-arm64"
-    deploymentId: "NA"
+    sourceBranch: "master"
+    deploymentId: "default"
     managed_by: packer
 tests:
   - microsoft_binscope.tests.ps1

--- a/config/windows_production_defaults.yaml
+++ b/config/windows_production_defaults.yaml
@@ -11,7 +11,7 @@ vm:
     sourceRepository: ronin_puppet
     sourceBranch: master
     managed_by: packer
-    deploymentId: "bb8cdb7"
+    deploymentId: "82415f4"
 images:
   production:
     - win10-64-2009


### PR DESCRIPTION
## Summary
Pin the production Windows images to ronin_puppet `82415f4`, up from `bb8cdb7`.

`82415f4` is the merge commit of [ronin_puppet#1244](https://github.com/mozilla-platform-ops/ronin_puppet/pull/1244) (RELOPS-2449), which skips NetFx3 and the DirectX SDK on ARM64 builders. All production configs inherit `deploymentId` from `windows_production_defaults.yaml`, so this moves every Windows production image onto that commit.

Also revert `win11-a64-25h2-builder-alpha` from the (now-merged) `relops-2449-skip-netfx3-arm64` feature branch back to `sourceBranch: master` / `deploymentId: default`, so the alpha builder tracks `82415f4` like the rest.

## Versions
`image_version` stays at `1.3.5` / `1.0.5`. The `bb8cdb7` builds at those versions were removed from the Shared Image Gallery, so the rebuild republishes the same version numbers from `82415f4` with no collision.

## Validation
The NetFx3 + DXSDK removal on this commit was validated end-to-end: the `win11-a64-25h2-builder-alpha` image built green, and a real ARM64 PGO build (`generate-profile-win64-aarch64-shippable`) passed on the alpha builder pool. See ronin_puppet#1244.
