### PR TITLE
ci(win-hw-wim): image input as choice dropdown

### DIFF
--- a/.github/workflows/win-hw-wim-build.yml
+++ b/.github/workflows/win-hw-wim-build.yml
@@ -16,8 +16,12 @@ on:
     inputs:
       image:
         description: "Image config to build (config/<image>.yaml)"
-        type: string
+        type: choice
         default: win11-24h2-hw
+        # Keep in sync with provisioners/windows/win-hw-wim/config/*.yaml on the pipeline branch.
+        options:
+          - win11-24h2-hw
+          - win11-24h2-hw-test
       pipeline_ref:
         description: "worker-images branch holding provisioners/windows/win-hw-wim"
         type: string


### PR DESCRIPTION
Re-applies the `type: choice` dropdown for the workflow_dispatch `image` input. The original change (a26a1b0) missed the #829 squash-merge, so `main` shipped `type: string`. Options kept in sync with the pipeline branch config/*.yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)