### PR TITLE
ci(win-hw-wim): reuse FXCI nontrusted image-creation creds

### DIFF
--- a/.github/workflows/win-hw-wim-build.yml
+++ b/.github/workflows/win-hw-wim-build.yml
@@ -7,9 +7,10 @@ run-name: "Windows HW WIM build - ${{ inputs.image }} @ ${{ inputs.pipeline_ref 
 #
 # Prerequisites (one-time):
 #   - The Azure build VM exists (provisioners/windows/win-hw-wim/New-WinHwWimBuildVm.ps1).
-#   - An OIDC service principal with a federated credential for this repo, granted
-#     Virtual Machine Contributor on rg-central-us-nuc-wim. Wire its ids as secrets:
-#       WIN_HW_WIM_AZURE_CLIENT_ID, WIN_HW_WIM_AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID (existing).
+#   - Reuses the existing FXCI (nontrusted) image-creation OIDC credentials — the same
+#     SP/secrets as sig-nontrusted.yml: AZURE_CLIENT_ID_FXCI, AZURE_SUBSCRIPTION_ID_UNTRUSTED,
+#     AZURE_TENANT_ID. That SP must be able to start + run-command the build VM in
+#     rg-central-us-nuc-wim (Virtual Machine Contributor there, if not already covered).
 
 on:
   workflow_dispatch:
@@ -62,9 +63,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
         with:
-          client-id: ${{ secrets.WIN_HW_WIM_AZURE_CLIENT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID_FXCI }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.WIN_HW_WIM_AZURE_SUBSCRIPTION_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_UNTRUSTED }}
 
       - name: Kick off Windows HW WIM build
         shell: pwsh


### PR DESCRIPTION
Switch the build workflow's azure/login to the existing **FXCI (nontrusted)** image-creation credentials — the same SP/secrets as `sig-nontrusted.yml` (`AZURE_CLIENT_ID_FXCI` / `AZURE_SUBSCRIPTION_ID_UNTRUSTED` / `AZURE_TENANT_ID`) — instead of new `WIN_HW_WIM_*` secrets. No new SP or secrets to create.

Note: that SP must be able to start + run-command the build VM in `rg-central-us-nuc-wim` (VM Contributor there, if not already covered by its FXCI-subscription rights).

🤖 Generated with [Claude Code](https://claude.com/claude-code)