### PR TITLE
MDC1Windows: point relops1213 deploy at the RELOPS-2487 feature branch (dev:)

### DIFF
--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -48,6 +48,10 @@ pools:
     openvox_version: "8.19.2"
     git_version: "2.50.0"
     Description: "NUC12 Hardware Performance Staging/Testing Pool"
+    # RELOPS-2487 canary: run this pool's deploy from the feature branch. OS-deploy.ps1
+    # on that branch refreshes pools.yml from it, so image/src_Branch/hash for the
+    # baked-WIM + DISM /Apply-Image test live on the branch, not here.
+    dev: "nuc-wim-pipeline"
     image: "win11-24H2-NUC-01-16-2025"
     src_Organisation: "mozilla-platform-ops"
     src_Repository: "ronin_puppet"


### PR DESCRIPTION
Adds `dev: nuc-wim-pipeline` to the **relops1213** pool so its NUC deployments run the MDC1Windows deploy scripts from the RELOPS-2487 feature branch. This is the canary for the pre-baked `install.wim` + `DISM /Apply-Image` deploy path (RELOPS-2487 track 2 — applying the baked image to the machine).

**Why only one line on main:** `OS-deploy.ps1` on `nuc-wim-pipeline` refreshes `pools.yml` from the dev branch during the dev re-run, so the rest of the canary config (`image` / `src_Branch` / `hash` → baked WIM + our ronin branch) lives on the feature branch. `main` only needs this trigger.

**Blast radius:** relops1213 only. Every other pool is untouched; removing this line returns relops1213 to the default deploy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)