### PR TITLE
MDC1Windows: relops1213 image -> win11-24h2-hw-test-20260730-192551

### DIFF
--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -52,7 +52,7 @@ pools:
     # on that branch refreshes pools.yml from it, so image/src_Branch/hash for the
     # baked-WIM + DISM /Apply-Image test live on the branch, not here.
     dev: "nuc-wim-pipeline"
-    image: "win11-24H2-NUC-01-16-2025"
+    image: "win11-24h2-hw-test-20260730-192551"
     src_Organisation: "mozilla-platform-ops"
     src_Repository: "ronin_puppet"
     src_Branch: "master"


### PR DESCRIPTION
Point the **relops1213** canary at the baked golden WIM `win11-24h2-hw-test-20260730-192551` (first successful bake carrying the RunDeployBootstrap startup task + baked OpenSSH). Deploy-test the first-boot bootstrap. Scoped to relops1213 only; every other pool unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)