### PR TITLE
Update ubuntu 24.04 images to generic-worker v103.0.1

### DIFF
--- a/config/gw-fxci-gcp-l1-2404-arm64-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-arm64-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-central1-a
 vm:
   disk_size: 60
-  taskcluster_version: 100.4.0
+  taskcluster_version: 103.0.1
   tc_arch: ARM64
   script_paths:
   - "scripts/linux/ubuntu-2404-headless-arm64-headless"

--- a/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-gui-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 100.4.0
+  taskcluster_version: 103.0.1
   tc_arch: AMD64
   script_paths:
   - "scripts/linux/ubuntu-2404-amd64-gui"

--- a/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
+++ b/config/gw-fxci-gcp-l1-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 100.4.0
+  taskcluster_version: 103.0.1
   tc_arch: AMD64
   script_paths:
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"

--- a/config/trusted-gw-fxci-gcp-l3-2404-arm64-headless-alpha.yaml
+++ b/config/trusted-gw-fxci-gcp-l3-2404-arm64-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-central1-a
 vm:
   disk_size: 60
-  taskcluster_version: 100.4.0
+  taskcluster_version: 103.0.1
   tc_arch: ARM64
   script_paths:
   - "scripts/linux/ubuntu-2404-headless-arm64-headless"

--- a/config/trusted-gw-fxci-gcp-l3-2404-headless-alpha.yaml
+++ b/config/trusted-gw-fxci-gcp-l3-2404-headless-alpha.yaml
@@ -7,7 +7,7 @@ image:
   zone: us-west1-a
 vm:
   disk_size: 60
-  taskcluster_version: 100.4.0
+  taskcluster_version: 103.0.1
   tc_arch: AMD64
   script_paths:
   - "scripts/linux/ubuntu-2404-headless-amd64-headless"


### PR DESCRIPTION
This picks up a fix for https://github.com/taskcluster/taskcluster/issues/8942 which made 100.4.0 unable to be deployed at all.