### PR TITLE
Pin Docker to 29.5.3 on GCP Ubuntu 24.04 images

### DIFF
--- a/scripts/linux/common/bootstrap.sh
+++ b/scripts/linux/common/bootstrap.sh
@@ -41,7 +41,14 @@ retry curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 retry apt-get update
-retry apt-get install -y docker-ce docker-ce-cli containerd.io
+# Docker 29.7.x cannot load Kaniko-built Firefox task images containing
+# absolute hardlink targets. Keep this pinned until moby/go-archive#100 ships
+# in a Docker release: https://github.com/moby/go-archive/issues/99
+DOCKER_VERSION='5:29.5.3-1~ubuntu.24.04~noble'
+retry apt-get install -y \
+  "docker-ce=${DOCKER_VERSION}" \
+  "docker-ce-cli=${DOCKER_VERSION}" \
+  containerd.io
 retry docker run hello-world
 
 # configure kvm vmware backdoor

--- a/scripts/linux/ubuntu-2404-amd64-gui/fxci/bootstrap.sh
+++ b/scripts/linux/ubuntu-2404-amd64-gui/fxci/bootstrap.sh
@@ -41,7 +41,14 @@ retry curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 retry apt-get update
-retry apt-get install -y docker-ce docker-ce-cli containerd.io
+# Docker 29.7.x cannot load Kaniko-built Firefox task images containing
+# absolute hardlink targets. Keep this pinned until moby/go-archive#100 ships
+# in a Docker release: https://github.com/moby/go-archive/issues/99
+DOCKER_VERSION='5:29.5.3-1~ubuntu.24.04~noble'
+retry apt-get install -y \
+  "docker-ce=${DOCKER_VERSION}" \
+  "docker-ce-cli=${DOCKER_VERSION}" \
+  containerd.io
 retry docker run hello-world
 
 # configure kvm vmware backdoor


### PR DESCRIPTION
## Summary

- pin `docker-ce` and `docker-ce-cli` to the last validated version, 29.5.3
- apply the pin to both GCP FXCI Ubuntu 24.04 bootstrap paths
- document the Docker 29.7.x hardlink regression and the upstream fix being tracked

## Why

Docker 29.7.x cannot load Kaniko-built Firefox task images containing absolute hardlink targets. This restores task-image loading while retaining Generic Worker 103.0.1.

Tracking issue: [RELOPS-2497](https://mozilla-hub.atlassian.net/browse/RELOPS-2497)
Upstream regression: [moby/go-archive#99](https://github.com/moby/go-archive/issues/99)
Upstream fix: [moby/go-archive#100](https://github.com/moby/go-archive/pull/100)

## Validation

- `bash -n` on both changed bootstrap scripts
- `uvx pre-commit run --files` on both changed files
- `packer validate gcp.pkr.hcl` with the x86-64 headless image variables
- verified the exact Docker CE and CLI package version exists in the Noble amd64 and arm64 repositories

## Post-merge validation

Rebuild the GCP Ubuntu 24.04 alpha images and run the full x86-64 headless OS integration group. Do not promote until the tier-1 integration set is green.