### PR TITLE
RELOPS-2496: refresh Win11 25H2 AMD alpha image

### DIFF
--- a/config/win11-64-25h2-alpha.yaml
+++ b/config/win11-64-25h2-alpha.yaml
@@ -45,7 +45,7 @@ tests:
   - power_management.tests.ps1
   - scheduled_tasks.tests.ps1
   - azure_vm_agent.tests.ps1
-  #- virtual_drivers.tests.ps1
+  - virtual_drivers.tests.ps1
   - logging.tests.ps1
   - sevenzip.tests.ps1
   - git.tests.ps1


### PR DESCRIPTION
## Summary

Prepare `win11-64-25h2-alpha` for a same-version rebuild on the AMD-backed alpha pool.

- restore `virtual_drivers.tests.ps1` so the alpha and production Windows 25H2 Pester lists match exactly
- retain alpha's `image.version: latest` behavior
- retain Azure Compute Gallery version `1.0.0`
- inherit `deploymentId: 82415f4` from `windows_production_defaults.yaml`, matching the current production ronin_puppet pin

## Why

The current alpha gallery image `1.0.0` was built from ronin_puppet `bb8cdb7`. Rebuilding it from `82415f4` lets us validate the AMD-backed `Standard_D8ads_v5` worker configuration against the production Puppet commit before running the complete Firefox tier-1 alpha-pool suite.

The virtual-driver Pester test was temporarily disabled before its assertions were updated for VB-CABLE pack 45. The current test checks the installed system driver and MEDIA PnP device and is already enabled for the production Windows 25H2 image.

## Validation

- `uvx pre-commit run --files config/win11-64-25h2-alpha.yaml`
- verified the alpha and production `tests:` arrays match exactly (23 Pester files)
- verified alpha retains `image.version: latest` and `sharedimage.image_version: 1.0.0`
- verified `deploymentId: default` resolves to `82415f4`

## Build plan

After merge, dispatch the one-off `FXCI - Azure` workflow from `main` for `win11-64-25h2-alpha`. Packer handles replacement of the existing alpha-only gallery version `1.0.0`. Verify the generated SBOM reports deployment `82415f4`, then run the complete Windows 25H2 tier-1 suite on `gecko-t/win11-64-25h2-alpha`.

[Jira: RELOPS-2496](https://mozilla-hub.atlassian.net/browse/RELOPS-2496)
