### PR TITLE
RELOPS-2496: pin Win11 25H2 alpha source image

### DIFF
--- a/config/win11-64-25h2-alpha.yaml
+++ b/config/win11-64-25h2-alpha.yaml
@@ -29,7 +29,7 @@ vm:
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
     sourceBranch: "master"
-    deploymentId: "82415f4"
+    deploymentId: "default"
     managed_by: packer
 tests:
   - win11_sdk_tests.ps1

--- a/config/win11-64-25h2-alpha.yaml
+++ b/config/win11-64-25h2-alpha.yaml
@@ -3,7 +3,7 @@ image:
   publisher: MicrosoftWindowsDesktop
   offer: Windows-11
   sku: win11-25h2-avd
-  version: latest
+  version: 26200.8655.260607
 sharedimage:
   gallery_name: "win11_64_25h2_alpha"
   image_name: "win11_64_25h2_alpha"
@@ -29,7 +29,7 @@ vm:
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
     sourceBranch: "master"
-    deploymentId: "default"
+    deploymentId: "82415f4"
     managed_by: packer
 tests:
   - win11_sdk_tests.ps1


### PR DESCRIPTION
## Summary

- pin `win11-64-25h2-alpha` to the previously working Windows marketplace image `26200.8655.260607`
- leave `deploymentId: "default"` so alpha inherits the ronin commit pinned in `windows_production_defaults.yaml`, matching production
- keep the Azure Compute Gallery image version at `1.0.0`
- leave the Pester test list unchanged

## Why

The rebuild from `latest` selected Windows `26200.8875.260711`. Packer and all 250 Pester tests passed, but VMs created from the published gallery image fail Azure OS provisioning before Generic Worker starts:

> This installation of Windows is undeployable. Make sure the image has been properly prepared (generalized).

Rebuilding with the known-good marketplace image while continuing to inherit the production ronin pin tests whether the newer marketplace image triggered the regression.

Failed integration task group: https://firefox-ci-tc.services.mozilla.com/tasks/groups/DfPybRndSTqpNDqYsrHqng

Failed image build and publication run: https://github.com/mozilla-platform-ops/worker-images/actions/runs/30920499747

Jira: https://mozilla-hub.atlassian.net/browse/RELOPS-2496

## Validation

- `uvx pre-commit run --files config/win11-64-25h2-alpha.yaml`
- confirmed `26200.8655.260607` is available for `MicrosoftWindowsDesktop:Windows-11:win11-25h2-avd` in eastus
