### PR TITLE
RELOPS-2500: prepare Win11 25H2 production image 1.0.6

### DIFF
--- a/config/win11-64-25h2.yaml
+++ b/config/win11-64-25h2.yaml
@@ -3,11 +3,11 @@ image:
   publisher: MicrosoftWindowsDesktop
   offer: Windows-11
   sku: win11-25h2-avd
-  version: 26200.8037.260306
+  version: 26200.8655.260607
 sharedimage:
   gallery_name: "win11_64_25h2"
   image_name: "win11_64_25h2"
-  image_version: "1.0.5"
+  image_version: "1.0.6"
 azure:
   managed_image_resource_group_name: "default"
   managed_image_storage_account_type: "default"
@@ -30,7 +30,7 @@ vm:
   puppet_version: "default"
   git_version: "default"
   openvox_version: "default"
-  size: Standard_F8s_v2
+  size: Standard_D8ads_v5
   tags:
     base_image: win116425h2azure
     worker_pool_id: win11-64-25h2


### PR DESCRIPTION
## Summary

- Updates `win11-64-25h2` from gallery version `1.0.5` to `1.0.6` and pins the Windows marketplace source to `26200.8655.260607`.
- Uses `Standard_D8ads_v5` for the temporary Packer build VM, matching the successful AMD alpha build path.
- Keeps OpenVox and `deploymentId` on the production defaults. They currently resolve to OpenVox `8.24.2` and ronin_puppet commit [`82415f4`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/82415f414bcda46a1e9152c9fa0c3f97d1974b9f).
- Does not change the production worker-pool SKU. The pool stays on `Standard_F8s_v2` while image `1.0.6` is validated.

## Why

The AMD alpha build using Windows source `26200.8655.260607` and ronin_puppet `82415f4` completed Packer and all Pester checks successfully in [worker-images run 30927780653](https://github.com/mozilla-platform-ops/worker-images/actions/runs/30927780653). A build from the newer `latest` source selected `26200.8875.260711`, but VMs created from that image failed Azure OS provisioning before Generic Worker started.

Publishing the known-good source as production `1.0.6` lets us validate the image on the current Intel pool before RELOPS-2496 changes the runtime compute SKU.

## Validation

- `uvx pre-commit run --files config/win11-64-25h2.yaml`
- Confirmed the production and alpha configs have identical Pester test lists.
- Confirmed gallery version `1.0.6` is not already published.
- Confirmed source `26200.8655.260607` is available in the production build region as an x64 Gen2 image.
- Confirmed `Standard_D8ads_v5` is available in the build region without restrictions and supports ephemeral OS disks.
- Confirmed `deploymentId: default` resolves to `82415f4`.

## Build plan

After merge, dispatch the one-off `FXCI - Azure` workflow for `win11-64-25h2`. Verify the published gallery version and SBOM before opening the fxci-config rollout PR. The image must pass the full Windows tier 1 set using the latest autoland decision-task baseline before the production pool changes to AMD.

## Related

- [RELOPS-2500](https://mozilla-hub.atlassian.net/browse/RELOPS-2500)
- [RELOPS-2496](https://mozilla-hub.atlassian.net/browse/RELOPS-2496)