### PR TITLE
RELOPS-2500: use Spot VM for Win11 25H2 Packer build

### DIFF
--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -157,6 +157,12 @@ variable "vm_size" {
   default = "${env("vm_size")}"
 }
 
+variable "use_spot" {
+  type        = bool
+  default     = false
+  description = "Whether to use an Azure Spot VM for the temporary Packer builder"
+}
+
 variable "worker_pool_id" {
   type    = string
   default = "${env("worker_pool_id")}"
@@ -238,6 +244,14 @@ source "azure-arm" "sig" {
   location                   = "${var.build_location}"
   vm_size                    = "${var.vm_size}"
   async_resourcegroup_delete = true
+
+  dynamic "spot" {
+    for_each = var.use_spot ? [1] : []
+    content {
+      eviction_policy = "Delete"
+      max_price       = -1
+    }
+  }
 
   # Shared image gallery https:github.com/mozilla-platform-ops/relops_infra_as_code/blob/master/terraform/azure_fx_nonci/worker-images.tf
   shared_image_gallery_destination {

--- a/bin/WorkerImages/Public/New-AzSharedWorkerImage.ps1
+++ b/bin/WorkerImages/Public/New-AzSharedWorkerImage.ps1
@@ -81,6 +81,7 @@ function New-AzSharedWorkerImage {
     Log-FinalValue "deploymentId"        $Y.vm.tags["deploymentId"]        $ImageYaml.vm.tags["deploymentId"]        $DefaultYaml.vm.tags["deploymentId"]
     Log-FinalValue "resource_group"      $Y.azure["managed_image_resource_group_name"] $ImageYaml.azure["managed_image_resource_group_name"] $DefaultYaml.azure["managed_image_resource_group_name"]
     Log-FinalValue "vmSize"              $Y.vm["size"]                     $ImageYaml.vm["size"]                    $DefaultYaml.vm["size"]
+    Log-FinalValue "spot"                $Y.vm["spot"]                     $ImageYaml.vm["spot"]                    $DefaultYaml.vm["spot"]
     Log-FinalValue "build_location"      $Y.azure["build_location"]        $ImageYaml.azure["build_location"]       $DefaultYaml.azure["build_location"]
 
     # Set environment variables
@@ -92,6 +93,7 @@ function New-AzSharedWorkerImage {
     $ENV:PKR_VAR_image_version = $Y.image["version"]
     $ENV:PKR_VAR_resource_group = $Y.azure["managed_image_resource_group_name"]
     $ENV:PKR_VAR_vm_size = $Y.vm["size"]
+    $ENV:PKR_VAR_use_spot = ($Y.vm["spot"] -eq $true).ToString().ToLowerInvariant()
     $BuildLocation = $Y.azure["build_location"]
     if ([string]::IsNullOrWhiteSpace($BuildLocation)) {
         $BuildLocation = "Central US"

--- a/config/README.md
+++ b/config/README.md
@@ -46,6 +46,7 @@ azure:
 
 ```
 vm:
+  spot: false # optional: use a Spot VM for the temporary Packer builder
   puppet_version: 8.5.1
   size: Standard_F8s_v2
   tags:

--- a/config/win11-64-25h2.yaml
+++ b/config/win11-64-25h2.yaml
@@ -27,6 +27,7 @@ azure:
     - westus2
     - westus3
 vm:
+  spot: true
   puppet_version: "default"
   git_version: "default"
   openvox_version: "default"

--- a/config/windows_production_defaults.yaml
+++ b/config/windows_production_defaults.yaml
@@ -3,6 +3,7 @@ azure:
   managed_image_resource_group_name: rg-packer-worker-images
   managed_image_storage_account_type: Standard_LRS
 vm:
+  spot: false
   puppet_version: 8.10.0
   git_version: 2.54.0
   openvox_version: 8.24.2


### PR DESCRIPTION
## Summary

- Add an opt-in Azure Spot setting for temporary SIG Packer builder VMs.
- Enable Spot only for win11-64-25h2; all other Windows production configs remain dedicated by default.
- Use Delete eviction and max price -1 so evicted builders do not linger and price alone does not evict them.

## Validation

- uvx pre-commit run on all changed files
- packer validate with Spot disabled and enabled
- PowerShell parser validation
- Confirmed win11-64-25h2 production and alpha Pester test lists match
- Autoreview clean with no actionable findings

## Related

- RELOPS-2500