### PR TITLE
Move 5 degraded nuc13 nodes to alpha pool

### DIFF
--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -188,6 +188,17 @@ pools:
     - nuc13-045
     - nuc13-006
     - nuc13-093
+    # Degraded performers moved out of win11-64-24h2-hw.
+    # nuc13-011: slightly underperforming.
+    - nuc13-011
+    # nuc13-012: slightly degraded for over a month.
+    - nuc13-012
+    # nuc13-032: degraded after 2026-07-22.
+    - nuc13-032
+    # nuc13-091: slightly degraded for over a month.
+    - nuc13-091
+    # nuc13-151: slightly degraded since 2026-07-12.
+    - nuc13-151
   - name: "win11-64-24h2-hw-perf-sheriff"
     openvox_version: "8.19.2"
     puppet_version: "8.10.0"
@@ -221,14 +232,11 @@ pools:
     - nuc13-008
     - nuc13-009
     - nuc13-010
-    - nuc13-011
-    - nuc13-012
     - nuc13-015
     - nuc13-016
     - nuc13-017
     - nuc13-018
     - nuc13-029
-    - nuc13-032
     - nuc13-033
     - nuc13-036
     - nuc13-040
@@ -252,7 +260,6 @@ pools:
     - nuc13-088
     - nuc13-089
     - nuc13-090
-    - nuc13-091
     - nuc13-096
     - nuc13-097
     - nuc13-101
@@ -273,7 +280,6 @@ pools:
     - nuc13-144
     - nuc13-145
     - nuc13-149
-    - nuc13-151
     - nuc13-153
     - nuc13-154
     - nuc13-156


### PR DESCRIPTION
Moves five degraded nuc13 nodes out of the production pool `win11-64-24h2-hw` and into `win11-64-24h2-hw-alpha` so they stop taking production Firefox CI work while they are investigated.

| Node | Reason |
|---|---|
| nuc13-011 | slightly underperforming |
| nuc13-012 | slightly degraded for over a month |
| nuc13-032 | degraded after 2026-07-22 |
| nuc13-091 | slightly degraded for over a month |
| nuc13-151 | slightly degraded since 2026-07-12 |

Each node carries an inline comment with its reason. Node counts: `win11-64-24h2-hw` 62 -> 57, `win11-64-24h2-hw-alpha` 82 -> 87; fleet total unchanged at 172, no duplicate entries.

Notes for review:

- **nuc13-011 was flagged as a "maybe"** (only slightly underperforming). Easy to drop from this PR if we'd rather leave it in production pending more data.
- Alpha runs branch `RELOPS-2402-fleetbench` (hash `74e8909`) rather than production `master`, so these five will pick up fleetbench on their next deploy. That is consistent with the alpha pool's stated purpose ("Questionable nodes - CPU suppression confirmed or notable floor events detected in stress testing"), but flagging it in case the intent was purely to pull them from production capacity without changing what they run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)