### PR TITLE
MDC1Windows: add dev trigger to perf-debug pool (RELOPS-2487 canary)

### DIFF
--- a/provisioners/windows/MDC1Windows/pools.yml
+++ b/provisioners/windows/MDC1Windows/pools.yml
@@ -77,6 +77,10 @@ pools:
     openvox_version: "8.19.2"
     git_version: "2.50.0"
     Description: "NUC12 Hardware Performance Staging/Testing Pool"
+    # RELOPS-2487 canary: run this pool's deploy from the feature branch. OS-deploy.ps1 on that
+    # branch refreshes pools.yml from it, so the baked-WIM + DISM /Apply-Image config
+    # (image/src_Branch/hash) lives on the branch; main only needs this `dev:` trigger.
+    dev: "nuc-wim-pipeline"
     image: "win11-24H2-NUC-01-16-2025"
     src_Organisation: "mozilla-platform-ops"
     src_Repository: "ronin_puppet"


### PR DESCRIPTION
Adds `dev: nuc-wim-pipeline` to the `win11-64-24h2-hw-perf-debug` pool so its deploy is driven from the RELOPS-2487 feature branch (same trigger `relops1213` already carries on main).

OS-deploy.ps1 reads pools.yml from the default branch first and only re-fetches the full config (image/src_Branch/hash + pools.yml) from the pool's `dev:` branch — so main just needs this one-line trigger; the baked-WIM + DISM /Apply-Image config lives on `nuc-wim-pipeline`.

Enables validating the pre-baked worker on nuc13-024 (perf-debug has working worker credentials, unlike relops1213). Revert with relops1213 when the canary is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)