### PR TITLE
RELOPS-2503: run OS integration tests on Windows HW pools

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -10,3 +10,13 @@ jobs:
           treeherder-symbol: run-integration-tests
           include-cron-input: true
       when: []  # never (hook only)
+
+    # Windows hardware pools; separate from the above so the two runs stay
+    # disjoint. Inert until fxci-config projects.yml lists this cron target.
+    - name: run-hw-integration-tests
+      job:
+          type: decision-task
+          target-tasks-method: hw-integration
+          treeherder-symbol: run-hw-integration-tests
+          include-cron-input: true
+      when: []  # never (hook only)

--- a/.github/workflows/hw-os-integration.yml
+++ b/.github/workflows/hw-os-integration.yml
@@ -1,0 +1,111 @@
+name: HW OS Integration Tests - FXCI
+run-name: HW OS Integration Tests - ${{ github.actor }}
+
+# Validates a WIM or ronin_puppet change without a try push (RELOPS-2503).
+# Dispatch-only: hardware needs a PXE deploy first. One checkbox per pool.
+
+on:
+  workflow_dispatch:
+    inputs:
+      win11_64_24h2_hw_alpha:
+        description: "win11-64-24h2-hw-alpha (nuc13, large staging pool)"
+        type: boolean
+        default: false
+      win11_64_24h2_hw_relops1213:
+        description: "win11-64-24h2-hw-relops1213 (baked-WIM canary)"
+        type: boolean
+        default: false
+      win11_64_24h2_hw_ref_alpha:
+        description: "win11-64-24h2-hw-ref-alpha (t-nuc12 reference)"
+        type: boolean
+        default: false
+      win11_64_24h2_hw_perf_debug:
+        description: "win11-64-24h2-hw-perf-debug"
+        type: boolean
+        default: false
+      win11_64_24h2_hw_perf_sheriff:
+        description: "win11-64-24h2-hw-perf-sheriff (single node - very slow)"
+        type: boolean
+        default: false
+      min_healthy_nodes:
+        description: "Refuse a pool with fewer active workers than this"
+        type: string
+        default: "1"
+      timeout_hours:
+        description: "Hours to wait for completion before giving up"
+        type: string
+        default: "6"
+      no_wait:
+        description: "Trigger and exit without waiting for results"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  check-access:
+    name: "Verify User Access"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Load Authorized Users and Check Access
+        shell: pwsh
+        run: ./ci/check-authorized-user.ps1
+
+  hw-integration-tests:
+    name: "Trigger HW Integration Tests"
+    needs: check-access
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Collect selected pools
+        id: pools
+        env:
+          SELECTED: >-
+            ${{ inputs.win11_64_24h2_hw_alpha && 'win11-64-24h2-hw-alpha,' || '' }}${{
+                inputs.win11_64_24h2_hw_relops1213 && 'win11-64-24h2-hw-relops1213,' || '' }}${{
+                inputs.win11_64_24h2_hw_ref_alpha && 'win11-64-24h2-hw-ref-alpha,' || '' }}${{
+                inputs.win11_64_24h2_hw_perf_debug && 'win11-64-24h2-hw-perf-debug,' || '' }}${{
+                inputs.win11_64_24h2_hw_perf_sheriff && 'win11-64-24h2-hw-perf-sheriff' || '' }}
+        run: |
+          pools="$(printf '%s' "$SELECTED" | tr -d '[:space:]' | sed 's/,*$//')"
+          if [ -z "$pools" ]; then
+            echo "::error ::No pool selected. Tick at least one pool checkbox."
+            exit 1
+          fi
+          echo "Selected pools: $pools"
+          echo "pools=$pools" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+
+      # Fails before any hardware time if a pool is unknown, production, or dead.
+      - name: Pre-flight
+        env:
+          POOLS: ${{ steps.pools.outputs.pools }}
+          MIN_HEALTHY: ${{ inputs.min_healthy_nodes }}
+          TASKCLUSTER_CLIENT_ID: ${{ secrets.TASKCLUSTER_OS_INT_CLIENT_ID }}
+          TASKCLUSTER_ACCESS_TOKEN: ${{ secrets.TASKCLUSTER_OS_INT_ACCESS_TOKEN }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          uv run ci/run-hw-os-integration.py "$POOLS" \
+            --min-healthy-nodes "$MIN_HEALTHY" \
+            --preflight-only
+
+      - name: Run HW OS Integration Tests
+        env:
+          POOLS: ${{ steps.pools.outputs.pools }}
+          MIN_HEALTHY: ${{ inputs.min_healthy_nodes }}
+          TIMEOUT_HOURS: ${{ inputs.timeout_hours }}
+          NO_WAIT: ${{ inputs.no_wait }}
+          TASKCLUSTER_CLIENT_ID: ${{ secrets.TASKCLUSTER_OS_INT_CLIENT_ID }}
+          TASKCLUSTER_ACCESS_TOKEN: ${{ secrets.TASKCLUSTER_OS_INT_ACCESS_TOKEN }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          args=(--min-healthy-nodes "$MIN_HEALTHY" --timeout "$(( TIMEOUT_HOURS * 3600 ))")
+          if [ "$NO_WAIT" = "true" ]; then
+            args+=(--no-wait)
+          fi
+          uv run ci/run-hw-os-integration.py "$POOLS" "${args[@]}"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -231,6 +231,9 @@ tasks:
                                       - $if: 'tasks_for == "cron" && cron["input"] && cron.input["images"]'
                                         then:
                                             DEPLOY_IMAGES: {$json: {$eval: cron.input.images}}
+                                      - $if: 'tasks_for == "cron" && cron["input"] && cron.input["pools"]'
+                                        then:
+                                            DEPLOY_HW_POOLS: {$json: {$eval: cron.input.pools}}
 
                               cache:
                                   "${trustDomain}-project-${project}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts

--- a/ci/run-hw-os-integration.py
+++ b/ci/run-hw-os-integration.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "taskcluster",
+#     "requests",
+#     "pyyaml",
+# ]
+# ///
+"""
+Run OS integration tests on MDC1 Windows hardware pools.
+
+Hardware counterpart to ci/run-os-integration.py, kept separate so pool logic
+stays off the cloud path. Pools are selected by name, pre-flighted for liveness
+and pools.yml agreement, production is refused, and zero tasks is a failure.
+
+Usage:
+    uv run ci/run-hw-os-integration.py <pool>[,<pool>...]
+    uv run ci/run-hw-os-integration.py win11-64-24h2-hw-relops1213 --no-wait
+    uv run ci/run-hw-os-integration.py --list
+
+Environment variables (required unless --list / --preflight-only):
+    TASKCLUSTER_CLIENT_ID      - Taskcluster client ID
+    TASKCLUSTER_ACCESS_TOKEN   - Taskcluster access token
+
+Optional:
+    TASKCLUSTER_ROOT_URL       - Defaults to https://firefox-ci-tc.services.mozilla.com
+    GITHUB_STEP_SUMMARY        - GitHub Actions step summary file (auto-detected)
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+import taskcluster
+
+IN_GITHUB_ACTIONS = os.environ.get("GITHUB_ACTIONS") == "true"
+
+HOOK_GROUP_ID = "project-releng"
+HOOK_ID = "cron-task-mozilla-platform-ops-worker-images/run-hw-integration-tests"
+
+DECISION_POLL_INTERVAL_SECONDS = 10
+# Hardware runs are long: a single speedometer3 task is ~20-40 minutes and a
+# small pool serialises them.
+DECISION_DISCOVERY_TIMEOUT_SECONDS = 1800
+TASK_GROUP_POLL_INTERVAL_SECONDS = 300
+TASK_GROUP_LOG_INTERVAL_SECONDS = 600
+DEFAULT_TIMEOUT_SECONDS = 6 * 60 * 60
+
+TASK_GROUP_ID_RE = re.compile(r'"taskGroupId":\s*"([A-Za-z0-9_-]{22})"')
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HW_POOLS_MODULE = (
+    REPO_ROOT / "taskcluster" / "worker_images_taskgraph" / "util" / "hw_pools.py"
+)
+
+
+def _load_hw_pools():
+    """Load by path: a package import would pull in mozilla_taskgraph."""
+    spec = importlib.util.spec_from_file_location("hw_pools", HW_POOLS_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+hw_pools = _load_hw_pools()
+
+
+def _escape_github_command_message(message: str) -> str:
+    return message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def log(level: str, message: str) -> None:
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    message = f"[{stamp}] {message}"
+
+    # Flush every line: stdout is block-buffered when piped, and without this
+    # errors on stderr overtake the stdout context that explains them.
+    if IN_GITHUB_ACTIONS and level in ("warning", "error"):
+        print(f"::{level}::{_escape_github_command_message(message)}", flush=True)
+        return
+    if level == "error":
+        sys.stdout.flush()
+        print(f"ERROR: {message}", file=sys.stderr, flush=True)
+    elif level == "warning":
+        print(f"WARNING: {message}", flush=True)
+    else:
+        print(message, flush=True)
+
+
+def notice(msg):
+    log("notice", msg)
+
+
+def warn(msg):
+    log("warning", msg)
+
+
+def error(msg):
+    log("error", msg)
+
+
+def format_duration(seconds: int) -> str:
+    if seconds < 0:
+        return "-"
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m {seconds % 60}s"
+    return f"{seconds // 3600}h {(seconds % 3600) // 60}m"
+
+
+def result_emoji(state: str) -> str:
+    return {
+        "pending": "⏳",
+        "running": "⏳",
+        "unscheduled": "⏳",
+        "completed": "✅",
+        "failed": "❌",
+        "exception": "⚠️",
+    }.get(state, "❓")
+
+
+# ---- pre-flight ----------------------------------------------------------- #
+
+
+def preflight(queue, registry, pool, min_healthy: int) -> dict:
+    """Check a pool is alive and matches pools.yml; ``ok`` False means skip it.
+
+    The worker list is claim-derived, so a low count usually just means idle; a
+    worker pools.yml assigns elsewhere is the real drift signal.
+    """
+    expected = set(registry.healthy_nodes(pool.name))
+    report = {
+        "pool": pool.name,
+        "identity": pool.identity,
+        "expected_nodes": len(expected),
+        "ok": True,
+        "problems": [],
+        "notes": [],
+    }
+
+    try:
+        data = queue.listWorkers(hw_pools.PROVISIONER_ID, pool.name)
+        workers = data.get("workers", []) if isinstance(data, dict) else []
+    except taskcluster.exceptions.TaskclusterRestFailure as exc:
+        report["ok"] = False
+        report["problems"].append(f"could not list workers: {exc}")
+        return report
+
+    seen = {w.get("workerId") for w in workers if w.get("workerId")}
+    quarantined = {
+        w.get("workerId") for w in workers if w.get("quarantineUntil")
+    }
+    active = seen - quarantined
+
+    report["workers_seen"] = len(seen)
+    report["quarantined"] = len(quarantined)
+    report["active"] = len(active)
+
+    # Nodes Taskcluster knows about that pools.yml assigns elsewhere.
+    foreign = {}
+    for worker_id in sorted(active):
+        if worker_id in expected:
+            continue
+        owner = next(
+            (n for n, p in registry.pools.items() if worker_id in p.nodes), None
+        )
+        foreign[worker_id] = owner or "unknown"
+    if foreign:
+        report["notes"].append(
+            "workers active in this queue that pools.yml assigns elsewhere: "
+            + ", ".join(f"{w} (pools.yml: {o})" for w, o in foreign.items())
+        )
+
+    missing = len(expected) - len(active & expected)
+    if missing:
+        report["notes"].append(
+            f"{missing} of {len(expected)} pools.yml nodes have not claimed work "
+            "recently (may simply be idle)"
+        )
+
+    if quarantined:
+        report["notes"].append(f"{len(quarantined)} worker(s) quarantined")
+
+    if len(active) < min_healthy:
+        report["ok"] = False
+        report["problems"].append(
+            f"only {len(active)} active worker(s), need at least {min_healthy}"
+        )
+
+    if pool.is_low_capacity:
+        report["notes"].append(
+            f"low capacity pool ({pool.node_count} node(s) in pools.yml); the "
+            "task graph will serialise"
+        )
+
+    try:
+        counts = queue.taskQueueCounts(pool.task_queue_id)
+        report["pending"] = counts.get("pendingTasks")
+        report["claimed"] = counts.get("claimedTasks")
+    except taskcluster.exceptions.TaskclusterRestFailure:
+        pass
+
+    return report
+
+
+def print_preflight(report: dict) -> None:
+    ident = report["identity"]
+    notice(
+        f"pre-flight {report['pool']}: "
+        f"image={ident['image']} branch={ident['src_branch']} rev={ident['revision']}"
+    )
+    notice(
+        f"  nodes(pools.yml)={report['expected_nodes']} "
+        f"active={report.get('active', 0)} quarantined={report.get('quarantined', 0)} "
+        f"pending={report.get('pending')} claimed={report.get('claimed')}"
+    )
+    for note in report["notes"]:
+        notice(f"  note: {note}")
+    for problem in report["problems"]:
+        error(f"  {report['pool']}: {problem}")
+
+
+# ---- trigger + monitor ---------------------------------------------------- #
+
+
+def trigger(hooks, pool_name: str) -> str:
+    payload = {"pools": [pool_name]}
+    notice(f"triggering hook for {pool_name}: {json.dumps(payload)}")
+    response = hooks.triggerHook(HOOK_GROUP_ID, HOOK_ID, payload)
+    return response["taskId"]
+
+
+def find_task_group(queue, decision_task_id: str, root_url: str) -> str | None:
+    """Scrape the task group the decision created; bounded by wall clock."""
+    deadline = time.time() + DECISION_DISCOVERY_TIMEOUT_SECONDS
+    last_state = None
+
+    while time.time() < deadline:
+        try:
+            state = queue.status(decision_task_id)["status"]["state"]
+            if state != last_state:
+                notice(f"  decision task {decision_task_id}: {state}")
+                last_state = state
+
+            if state in ("completed", "failed", "exception"):
+                artifact = queue.getLatestArtifact(
+                    decision_task_id, "public/logs/live_backing.log"
+                )
+                if isinstance(artifact, dict) and "url" in artifact:
+                    resp = requests.get(artifact["url"], timeout=60)
+                    for match in TASK_GROUP_ID_RE.findall(resp.text):
+                        if match != decision_task_id:
+                            return match
+
+                if state != "completed":
+                    error(
+                        f"  decision task {state}: {root_url}/tasks/{decision_task_id}"
+                    )
+                    return None
+                # Completed but no group id yet: the log may still be flushing.
+        except taskcluster.exceptions.TaskclusterRestFailure as exc:
+            notice(f"  waiting on decision task artifacts ({exc})")
+
+        time.sleep(DECISION_POLL_INTERVAL_SECONDS)
+
+    error(f"  timed out waiting for decision task {decision_task_id}")
+    return None
+
+
+def tally(tasks: list[dict]) -> dict:
+    states = [t["status"]["state"] for t in tasks]
+    return {
+        "total": len(states),
+        "completed": sum(1 for s in states if s == "completed"),
+        "failed": sum(1 for s in states if s == "failed"),
+        "exception": sum(1 for s in states if s == "exception"),
+        "pending": sum(
+            1 for s in states if s in ("pending", "running", "unscheduled")
+        ),
+    }
+
+
+def monitor(queue, runs: list[dict], timeout: int, root_url: str) -> None:
+    """Poll every run's task group until all are resolved or the timeout hits."""
+    start = time.time()
+    last_log = None
+
+    while time.time() - start < timeout:
+        outstanding = 0
+        for run in runs:
+            if run.get("done"):
+                continue
+            try:
+                response = queue.listTaskGroup(run["task_group_id"])
+            except taskcluster.exceptions.TaskclusterRestFailure as exc:
+                warn(f"  {run['pool']}: error listing task group: {exc}")
+                outstanding += 1
+                continue
+
+            run["tasks"] = response.get("tasks", [])
+            run["counts"] = tally(run["tasks"])
+            if run["counts"]["pending"] == 0:
+                run["done"] = True
+            else:
+                outstanding += 1
+
+        now = time.time()
+        if last_log is None or now - last_log >= TASK_GROUP_LOG_INTERVAL_SECONDS:
+            elapsed = format_duration(int(now - start))
+            for run in runs:
+                c = run.get("counts")
+                if c:
+                    notice(
+                        f"  ({elapsed}) {run['pool']}: {c['completed']}/{c['total']} "
+                        f"completed, {c['failed']} failed, {c['exception']} exception, "
+                        f"{c['pending']} pending/running"
+                    )
+            last_log = now
+
+        if outstanding == 0:
+            return
+        time.sleep(TASK_GROUP_POLL_INTERVAL_SECONDS)
+
+    for run in runs:
+        if not run.get("done"):
+            run["timed_out"] = True
+
+
+def write_github_summary(runs: list[dict], root_url: str) -> None:
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_file:
+        return
+
+    lines = ["## HW OS Integration Tests", ""]
+
+    lines += [
+        "| Pool | Image | Branch | Revision | Result | Passed | Failed | Exception | Pending |",
+        "|---|---|---|---|:---:|:---:|:---:|:---:|:---:|",
+    ]
+    for run in runs:
+        ident = run["identity"]
+        c = run.get("counts") or {}
+        verdict = run.get("verdict", "not started")
+        lines.append(
+            "| [{pool}]({url}) | `{image}` | `{branch}` | `{rev}` | {verdict} | "
+            "{ok} | {failed} | {exc} | {pending} |".format(
+                pool=run["pool"],
+                url=f"{root_url}/tasks/groups/{run['task_group_id']}"
+                if run.get("task_group_id")
+                else f"{root_url}/tasks/{run.get('decision_task_id', '')}",
+                image=ident.get("image"),
+                branch=ident.get("src_branch"),
+                rev=ident.get("revision"),
+                verdict=verdict,
+                ok=c.get("completed", "-"),
+                failed=c.get("failed", "-"),
+                exc=c.get("exception", "-"),
+                pending=c.get("pending", "-"),
+            )
+        )
+    lines.append("")
+
+    for run in runs:
+        if not run.get("tasks"):
+            continue
+        lines += [
+            f"### {run['pool']}",
+            "",
+            "| Status | Task | State | Duration |",
+            "|:---:|---|---|---|",
+        ]
+        for task in run["tasks"]:
+            status = task["status"]
+            task_id = status["taskId"]
+            name = task.get("task", {}).get("metadata", {}).get("name", task_id)
+            duration = "-"
+            runs_ = status.get("runs") or []
+            if runs_:
+                started = runs_[-1].get("started")
+                resolved = runs_[-1].get("resolved")
+                if started and resolved:
+                    a = datetime.fromisoformat(started.replace("Z", "+00:00"))
+                    b = datetime.fromisoformat(resolved.replace("Z", "+00:00"))
+                    duration = format_duration(int((b - a).total_seconds()))
+            lines.append(
+                f"| {result_emoji(status['state'])} | "
+                f"[{name}]({root_url}/tasks/{task_id}) | {status['state']} | {duration} |"
+            )
+        lines.append("")
+
+    Path(summary_file).open("a").write("\n".join(lines))
+
+
+# --------------------------------------------------------------------------- #
+
+
+def parse_pools(values: list[str]) -> list[str]:
+    names: list[str] = []
+    for value in values:
+        names.extend(p.strip() for p in value.split(",") if p.strip())
+    return list(dict.fromkeys(names))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run OS integration tests on Windows hardware pools"
+    )
+    parser.add_argument(
+        "pools",
+        nargs="*",
+        help="Hardware pool name(s) from pools.yml; comma-separated or repeated",
+    )
+    parser.add_argument(
+        "--list", action="store_true", help="List targetable pools and exit"
+    )
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help="Run the pre-flight checks and exit without triggering anything",
+    )
+    parser.add_argument(
+        "--min-healthy-nodes",
+        type=int,
+        default=1,
+        help="Refuse a pool with fewer active workers than this (default: 1)",
+    )
+    parser.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help="Trigger without checking pool health (not recommended)",
+    )
+    parser.add_argument("--no-wait", action="store_true", help="Exit after triggering")
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"Seconds to wait for completion (default: {DEFAULT_TIMEOUT_SECONDS})",
+    )
+    args = parser.parse_args()
+
+    registry = hw_pools.load_registry(REPO_ROOT)
+
+    if args.list:
+        print("Targetable hardware pools:")
+        for name, pool in registry.targetable.items():
+            print(
+                f"  {name:34s} nodes={pool.node_count:3d} "
+                f"image={pool.image} branch={pool.src_branch} rev={pool.revision}"
+            )
+        refused = [n for n, p in registry.pools.items() if p.is_production]
+        print("\nProduction (refused): " + ", ".join(refused))
+        return 0
+
+    requested = parse_pools(args.pools)
+    if not requested:
+        parser.error("no pools given; use --list to see the targetable pools")
+
+    try:
+        pools = registry.resolve(requested)
+    except hw_pools.HwPoolError as exc:
+        error(str(exc))
+        return 2
+
+    os.environ.setdefault(
+        "TASKCLUSTER_ROOT_URL", "https://firefox-ci-tc.services.mozilla.com"
+    )
+    root_url = os.environ["TASKCLUSTER_ROOT_URL"].rstrip("/")
+
+    options = taskcluster.optionsFromEnvironment()
+    queue = taskcluster.Queue(options)
+
+    # ---- pre-flight ------------------------------------------------------- #
+    if not args.skip_preflight:
+        reports = [
+            preflight(queue, registry, pool, args.min_healthy_nodes) for pool in pools
+        ]
+        for report in reports:
+            print_preflight(report)
+        blocked = [r for r in reports if not r["ok"]]
+        if blocked:
+            error(
+                "pre-flight failed for: " + ", ".join(r["pool"] for r in blocked)
+            )
+            return 1
+        if args.preflight_only:
+            notice("pre-flight only: not triggering")
+            return 0
+    elif args.preflight_only:
+        parser.error("--preflight-only and --skip-preflight are mutually exclusive")
+
+    for var in ("TASKCLUSTER_CLIENT_ID", "TASKCLUSTER_ACCESS_TOKEN"):
+        if not os.environ.get(var):
+            error(f"{var} is not set")
+            return 1
+
+    hooks = taskcluster.Hooks(options)
+
+    # ---- trigger ---------------------------------------------------------- #
+    runs = []
+    for pool in pools:
+        decision_task_id = trigger(hooks, pool.name)
+        notice(f"  {pool.name}: decision {root_url}/tasks/{decision_task_id}")
+        runs.append(
+            {
+                "pool": pool.name,
+                "identity": pool.identity,
+                "decision_task_id": decision_task_id,
+            }
+        )
+
+    if args.no_wait:
+        notice("--no-wait specified, exiting")
+        write_github_summary(runs, root_url)
+        return 0
+
+    # ---- discover task groups --------------------------------------------- #
+    for run in runs:
+        group = find_task_group(queue, run["decision_task_id"], root_url)
+        if not group:
+            run["verdict"] = "⚠️ decision failed"
+            continue
+        run["task_group_id"] = group
+        notice(f"  {run['pool']}: results {root_url}/tasks/groups/{group}")
+
+    live = [r for r in runs if r.get("task_group_id")]
+    if not live:
+        error("no task groups were created")
+        write_github_summary(runs, root_url)
+        return 1
+
+    monitor(queue, live, args.timeout, root_url)
+
+    # ---- verdicts --------------------------------------------------------- #
+    failed_overall = False
+    for run in runs:
+        counts = run.get("counts")
+        if run.get("verdict"):
+            failed_overall = True
+            continue
+        if run.get("timed_out"):
+            run["verdict"] = "⏳ timed out"
+            failed_overall = True
+        elif not counts or counts["total"] == 0:
+            # The cloud script calls this a pass; an empty graph means nothing
+            # replicated, which is a failure.
+            run["verdict"] = "❌ no tasks scheduled"
+            error(
+                f"{run['pool']}: decision created an empty task group -- nothing "
+                "was replicated. Check that mozilla-central scheduled hardware "
+                "tasks and that the pool is spelled as in pools.yml."
+            )
+            failed_overall = True
+        elif counts["failed"] or counts["exception"]:
+            run["verdict"] = "❌ failed"
+            failed_overall = True
+        else:
+            run["verdict"] = "✅ passed"
+
+    write_github_summary(runs, root_url)
+
+    for run in runs:
+        counts = run.get("counts") or {}
+        notice(
+            f"{run['pool']}: {run['verdict']} "
+            f"({counts.get('completed', 0)}/{counts.get('total', 0)} completed) "
+            f"image={run['identity']['image']} rev={run['identity']['revision']}"
+        )
+
+    return 1 if failed_overall else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/taskcluster/kinds/hw-integration-test/kind.yml
+++ b/taskcluster/kinds/hw-integration-test/kind.yml
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+# No mozilla_taskgraph.transforms.replicate here: it discards releng-hardware
+# tasks, so hw_integration_test does the equivalent work itself.
+transforms:
+  - worker_images_taskgraph.transforms.hw_integration_test
+
+tasks:
+  gecko-hw:
+    description: "Run in-tree Firefox tests on MDC1 Windows hardware pools"
+    hw-replicate:
+      # The push decision, not decision-os-integration: os-integration schedules
+      # no hardware tasks, a push schedules a few with dependencies resolved.
+      target: gecko.v2.mozilla-central.latest.taskgraph.decision
+      provisioner: releng-hardware
+      # Windows only; MDC1 macOS shares the releng-hardware provisioner.
+      worker-type-prefixes:
+        - win11-64-
+        - win11-a64-

--- a/taskcluster/test/test_hw_integration_test_transform.py
+++ b/taskcluster/test/test_hw_integration_test_transform.py
@@ -1,0 +1,437 @@
+import importlib
+import os
+import sys
+import textwrap
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Shaped like pools.yml: two production pools, three staging, one Known-BAD.
+POOLS_YAML = textwrap.dedent(
+    """\
+    ---
+    pools:
+      - name: "win11-64-24h2-hw"
+        Description: "Production"
+        image: "win11-24H2-NUC-01-16-2025"
+        src_Organisation: "mozilla-platform-ops"
+        src_Repository: "ronin_puppet"
+        src_Branch: "master"
+        hash: "655bf64"
+        secret_date: "02-24-2026"
+        domain_suffix: "wintest2.releng.mdc1.mozilla.com"
+        nodes:
+        - nuc13-004
+        - nuc13-005
+      - name: "win11-64-24h2-hw-ref"
+        Description: "Production reference"
+        image: "win11-24H2-NUC-01-16-2025"
+        src_Branch: "master"
+        hash: "655bf64"
+        domain_suffix: "wintest2.releng.mdc1.mozilla.com"
+        nodes:
+        - t-nuc12-004
+      - name: "win11-64-24h2-hw-alpha"
+        Description: "Staging"
+        image: "win11-24H2-NUC-01-16-2025"
+        src_Branch: "RELOPS-2402-fleetbench"
+        hash: "74e8909"
+        domain_suffix: "wintest2.releng.mdc1.mozilla.com"
+        nodes:
+        - nuc13-001
+        - nuc13-003
+        - nuc13-027
+        - nuc13-038
+        - nuc13-112
+      - name: "win11-64-24h2-hw-relops1213"
+        Description: "Baked WIM canary"
+        dev: "nuc-wim-pipeline"
+        image: "win11-24h2-hw-test-20260730-223108"
+        src_Branch: "master"
+        hash: "edef633"
+        domain_suffix: "wintest2.releng.mdc1.mozilla.com"
+        nodes:
+        - nuc13-159
+        - nuc13-160
+        - nuc13-035
+        - nuc13-060
+      - name: "win11-64-24h2-hw-perf-sheriff"
+        Description: "Single node"
+        image: "win11-24H2-NUC-01-16-2025"
+        src_Branch: "master"
+        hash: "7511c8e"
+        domain_suffix: "wintest2.releng.mdc1.mozilla.com"
+        nodes:
+        - nuc13-021
+    defaults:
+      NV_domain: "mdc1.mozilla.com"
+    Known-BAD:
+      nuc13:
+        - nuc13-112
+        - t-nuc12-001
+    """
+)
+
+
+def _source_task(
+    name="test-windows11-64-24h2-hw-ref-shippable/opt-mochitest-media-mda-gpu",
+    worker_type="win11-64-24h2-hw-ref",
+    scopes=None,
+):
+    """A source task shaped like a real mozilla-central Windows HW task."""
+    if scopes is None:
+        scopes = [
+            "secrets:get:project/perftest/gecko/level-3/perftest-login",
+            "generic-worker:cache:gecko-level-3-pip",
+            "generic-worker:cache:gecko-level-3-uv",
+            "generic-worker:os-group:releng-hardware/win11-64-24h2-hw-ref/admin",
+        ]
+    return {
+        "label": name,
+        "attributes": {"test_platform": "windows11-64-24h2-hw-ref-shippable"},
+        "dependencies": ["EPVLzXYQS8mqKN7Wkp0IIg", "VrVC0un-TJ-KGP8tePwtAA"],
+        "task": {
+            "provisionerId": "releng-hardware",
+            "workerType": worker_type,
+            "schedulerId": "gecko-level-3",
+            "taskGroupId": "ZUZ6G0U3Qa22ttrDk55vUA",
+            "priority": "high",
+            "created": "2026-08-03T06:01:28.802Z",
+            "deadline": "2026-08-04T06:01:28.802Z",
+            "expires": "2027-08-03T06:01:28.802Z",
+            "routes": [
+                "index.gecko.v2.mozilla-central.latest.firefox.win64",
+                "tc-treeherder.v2.mozilla-central.abcdef",
+            ],
+            "scopes": scopes,
+            "dependencies": ["EPVLzXYQS8mqKN7Wkp0IIg", "VrVC0un-TJ-KGP8tePwtAA"],
+            "metadata": {"name": name, "description": "a test task", "owner": "x@y"},
+            "extra": {"treeherder": {"symbol": "mda"}, "suite": "mochitest"},
+            "payload": {
+                "maxRunTime": 5400,
+                "cache": {"gecko-level-3-pip": "pip", "gecko-level-3-uv": "uv"},
+                "mounts": [
+                    {"cacheName": "gecko-level-3-pip", "directory": "pip"},
+                    {"content": {"taskId": "VrVC0un-TJ-KGP8tePwtAA"}, "file": "x"},
+                ],
+                "artifacts": [
+                    {"name": "public/logs", "path": "logs", "expires": "2027-01-01T00:00:00Z"}
+                ],
+                "env": {
+                    "GECKO_HEAD_REV": "deadbeefcafe",
+                    "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/mozilla-central",
+                    "MOZ_AUTOMATION": "1",
+                },
+            },
+        },
+    }
+
+
+def _load_transform_module():
+    """Stub taskgraph as test_integration_test_transform.py does.
+
+    hw_pools is left real -- it only needs PyYAML, so it gets genuine coverage.
+    """
+    mozilla_taskgraph_module = types.ModuleType("mozilla_taskgraph")
+    setattr(mozilla_taskgraph_module, "register", lambda graph_config: None)
+    sys.modules["mozilla_taskgraph"] = mozilla_taskgraph_module
+
+    taskgraph_module = types.ModuleType("taskgraph")
+    transforms_module = types.ModuleType("taskgraph.transforms")
+    base_module = types.ModuleType("taskgraph.transforms.base")
+    util_module = types.ModuleType("taskgraph.util")
+    util_taskcluster_module = types.ModuleType("taskgraph.util.taskcluster")
+
+    class DummyTransformSequence:
+        def add(self, fn):
+            return fn
+
+    setattr(base_module, "TransformSequence", DummyTransformSequence)
+    setattr(util_taskcluster_module, "find_task_id", lambda _: "stub-decision-id")
+    setattr(util_taskcluster_module, "get_artifact", lambda *_: {})
+
+    sys.modules["taskgraph"] = taskgraph_module
+    sys.modules["taskgraph.transforms"] = transforms_module
+    sys.modules["taskgraph.transforms.base"] = base_module
+    sys.modules["taskgraph.util"] = util_module
+    sys.modules["taskgraph.util.taskcluster"] = util_taskcluster_module
+
+    return importlib.import_module(
+        "worker_images_taskgraph.transforms.hw_integration_test"
+    )
+
+
+class GraphConfig(dict):
+    """dict plus the `root_dir` attribute taskgraph exposes."""
+
+    def __init__(self, root_dir, **kwargs):
+        super().__init__(**kwargs)
+        self.root_dir = root_dir
+
+
+class DummyConfig:
+    kind = "hw-integration-test"
+
+    def __init__(self, repo_root, hw_pools, level="3"):
+        self.params = {"hw_pools": hw_pools, "level": level}
+        self.graph_config = GraphConfig(
+            str(Path(repo_root) / "taskcluster"), **{"trust-domain": "relops"}
+        )
+
+
+class HwPoolsTestBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_transform_module()
+        cls.hw_pools = importlib.import_module("worker_images_taskgraph.util.hw_pools")
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        root = Path(self._tmp.name)
+        (root / "provisioners" / "windows" / "MDC1Windows").mkdir(parents=True)
+        (root / "provisioners" / "windows" / "MDC1Windows" / "pools.yml").write_text(
+            POOLS_YAML
+        )
+        (root / "taskcluster").mkdir()
+        self.root = root
+        self.addCleanup(self._tmp.cleanup)
+
+
+class TestHwPoolRegistry(HwPoolsTestBase):
+    def test_parses_pools_and_identity(self):
+        reg = self.hw_pools.load_registry(self.root)
+        self.assertEqual(len(reg.pools), 5)
+
+        pool = reg["win11-64-24h2-hw-relops1213"]
+        self.assertEqual(pool.task_queue_id, "releng-hardware/win11-64-24h2-hw-relops1213")
+        self.assertEqual(
+            pool.identity,
+            {
+                "image": "win11-24h2-hw-test-20260730-223108",
+                "src_branch": "master",
+                "revision": "edef633",
+            },
+        )
+        self.assertEqual(pool.dev_branch, "nuc-wim-pipeline")
+        self.assertEqual(
+            pool.fqdn("nuc13-159"), "nuc13-159.wintest2.releng.mdc1.mozilla.com"
+        )
+
+    def test_production_pools_identified_without_a_deny_list(self):
+        reg = self.hw_pools.load_registry(self.root)
+        self.assertTrue(reg["win11-64-24h2-hw"].is_production)
+        self.assertTrue(reg["win11-64-24h2-hw-ref"].is_production)
+        for staging in (
+            "win11-64-24h2-hw-alpha",
+            "win11-64-24h2-hw-relops1213",
+            "win11-64-24h2-hw-perf-sheriff",
+        ):
+            self.assertFalse(reg[staging].is_production, staging)
+        self.assertEqual(len(reg.targetable), 3)
+
+    def test_resolve_refuses_production_unknown_and_empty(self):
+        reg = self.hw_pools.load_registry(self.root)
+        for bad in (
+            ["win11-64-24h2-hw"],
+            ["win11-64-24h2-hw-ref"],
+            ["win11-64-24h2-hw-alpha", "win11-64-24h2-hw"],
+            ["does-not-exist"],
+            [],
+        ):
+            with self.assertRaises(self.hw_pools.HwPoolError, msg=repr(bad)):
+                reg.resolve(bad)
+
+    def test_resolve_dedupes_and_uses_pools_yaml_order(self):
+        reg = self.hw_pools.load_registry(self.root)
+        resolved = reg.resolve(
+            [
+                "win11-64-24h2-hw-relops1213",
+                "win11-64-24h2-hw-alpha",
+                "win11-64-24h2-hw-relops1213",
+            ]
+        )
+        self.assertEqual(
+            [p.name for p in resolved],
+            ["win11-64-24h2-hw-alpha", "win11-64-24h2-hw-relops1213"],
+        )
+
+    def test_known_bad_nodes_excluded_from_healthy(self):
+        reg = self.hw_pools.load_registry(self.root)
+        self.assertIn("nuc13-112", reg.known_bad_nodes)
+        self.assertEqual(reg["win11-64-24h2-hw-alpha"].node_count, 5)
+        self.assertEqual(len(reg.healthy_nodes("win11-64-24h2-hw-alpha")), 4)
+
+    def test_low_capacity_flag(self):
+        reg = self.hw_pools.load_registry(self.root)
+        self.assertTrue(reg["win11-64-24h2-hw-perf-sheriff"].is_low_capacity)
+        self.assertFalse(reg["win11-64-24h2-hw-alpha"].is_low_capacity)
+
+
+class TestHwIntegrationTransform(HwPoolsTestBase):
+    def setUp(self):
+        super().setUp()
+        os.environ["TASK_ID"] = "DECISIONTASKID12345678"
+        self.addCleanup(os.environ.pop, "TASK_ID", None)
+
+    def _run(self, hw_pools, sources=None, task_name="gecko-hw"):
+        if sources is None:
+            sources = [_source_task()]
+        self.mod._fetch_source_tasks = lambda *a, **k: sources
+        task = {
+            "name": task_name,
+            "description": "d",
+            "hw-replicate": {
+                "target": "gecko.v2.mozilla-central.latest.taskgraph.decision",
+                "provisioner": "releng-hardware",
+                "worker-type-prefixes": ["win11-64-", "win11-a64-"],
+            },
+        }
+        config = DummyConfig(self.root, hw_pools)
+        return list(self.mod.replicate_onto_hw_pools(config, [task]))
+
+    def test_no_pools_requested_emits_nothing_and_does_not_fetch(self):
+        called = []
+        self.mod._fetch_source_tasks = lambda *a, **k: called.append(1) or []
+        task = {
+            "name": "gecko-hw",
+            "hw-replicate": {
+                "target": "idx",
+                "provisioner": "releng-hardware",
+                "worker-type-prefixes": ["win11-64-"],
+            },
+        }
+        out = list(
+            self.mod.replicate_onto_hw_pools(DummyConfig(self.root, None), [task])
+        )
+        self.assertEqual(out, [])
+        self.assertEqual(called, [], "must not hit the network on a normal decision")
+
+    def test_production_pool_request_raises(self):
+        with self.assertRaises(self.hw_pools.HwPoolError):
+            self._run(["win11-64-24h2-hw"])
+
+    def test_retargets_worker_type_and_keeps_provisioner(self):
+        out = self._run(["win11-64-24h2-hw-relops1213"])
+        self.assertEqual(len(out), 1)
+        task = out[0]["task"]
+        self.assertEqual(task["provisionerId"], "releng-hardware")
+        self.assertEqual(task["workerType"], "win11-64-24h2-hw-relops1213")
+        self.assertEqual(task["schedulerId"], "relops-level-3")
+        self.assertEqual(task["taskGroupId"], "DECISIONTASKID12345678")
+        self.assertEqual(task["priority"], "low")
+
+    def test_one_task_per_pool_with_unique_labels(self):
+        out = self._run(["win11-64-24h2-hw-relops1213", "win11-64-24h2-hw-alpha"])
+        self.assertEqual(len(out), 2)
+        labels = [t["label"] for t in out]
+        self.assertEqual(len(set(labels)), 2)
+        for t in out:
+            self.assertIn(t["attributes"]["hw_pool"], t["label"])
+            self.assertEqual(t["task"]["metadata"]["name"], t["label"])
+
+    def test_gecko_routes_and_treeherder_are_stripped(self):
+        out = self._run(["win11-64-24h2-hw-alpha"])
+        task = out[0]["task"]
+        self.assertEqual(task["routes"], [])
+        self.assertNotIn("treeherder", task["extra"])
+        # non-treeherder extra keys survive
+        self.assertEqual(task["extra"]["suite"], "mochitest")
+
+    def test_cache_names_and_scopes_rewritten_consistently(self):
+        out = self._run(["win11-64-24h2-hw-alpha"])
+        task = out[0]["task"]
+        self.assertEqual(
+            sorted(task["payload"]["cache"]),
+            ["relops-level-3-pip", "relops-level-3-uv"],
+        )
+        self.assertEqual(task["payload"]["mounts"][0]["cacheName"], "relops-level-3-pip")
+        cache_scopes = sorted(
+            s for s in task["scopes"] if s.startswith("generic-worker:cache:")
+        )
+        self.assertEqual(
+            cache_scopes,
+            [
+                "generic-worker:cache:relops-level-3-pip",
+                "generic-worker:cache:relops-level-3-uv",
+            ],
+        )
+        # every cache the task mounts must have a matching scope
+        for name in task["payload"]["cache"]:
+            self.assertIn(f"generic-worker:cache:{name}", task["scopes"])
+
+    def test_pool_bound_os_group_scope_retargeted(self):
+        out = self._run(["win11-64-24h2-hw-alpha"])
+        self.assertIn(
+            "generic-worker:os-group:releng-hardware/win11-64-24h2-hw-alpha/admin",
+            out[0]["task"]["scopes"],
+        )
+
+    def test_unholdable_secret_scope_dropped(self):
+        out = self._run(["win11-64-24h2-hw-alpha"])
+        scopes = out[0]["task"]["scopes"]
+        self.assertFalse(
+            [s for s in scopes if s.startswith("secrets:")],
+            "secret scopes must be dropped, not carried or level-rewritten",
+        )
+
+    def test_datestamps_made_relative(self):
+        out = self._run(["win11-64-24h2-hw-alpha"])
+        task = out[0]["task"]
+        self.assertEqual(task["created"], {"relative-datestamp": "0 seconds"})
+        self.assertEqual(task["deadline"], {"relative-datestamp": "1 day"})
+        self.assertEqual(task["expires"], {"relative-datestamp": "1 month"})
+        self.assertEqual(
+            task["payload"]["artifacts"][0]["expires"],
+            {"relative-datestamp": "1 month"},
+        )
+
+    def test_gecko_revision_env_and_resolved_deps_preserved(self):
+        out = self._run(["win11-64-24h2-hw-alpha"])
+        task = out[0]["task"]
+        # Unlike the cloud path we keep *_REV: the resolved dependency task ids
+        # point at builds of exactly this revision.
+        self.assertEqual(task["payload"]["env"]["GECKO_HEAD_REV"], "deadbeefcafe")
+        self.assertEqual(
+            task["dependencies"],
+            ["EPVLzXYQS8mqKN7Wkp0IIg", "VrVC0un-TJ-KGP8tePwtAA"],
+        )
+        # nothing for taskgraph to resolve by label
+        self.assertEqual(out[0]["dependencies"], {})
+
+    def test_attributes_record_pool_identity_for_reporting(self):
+        out = self._run(["win11-64-24h2-hw-relops1213"])
+        attrs = out[0]["attributes"]
+        self.assertEqual(attrs["hw_replicate"], "gecko-hw")
+        self.assertEqual(attrs["hw_pool"], "win11-64-24h2-hw-relops1213")
+        self.assertEqual(attrs["hw_pool_image"], "win11-24h2-hw-test-20260730-223108")
+        self.assertEqual(attrs["hw_pool_branch"], "master")
+        self.assertEqual(attrs["hw_pool_revision"], "edef633")
+        # crucially NOT the cloud attribute, which target.py's `integration`
+        # method selects on
+        self.assertNotIn("replicate", attrs)
+
+    def test_source_task_is_not_mutated(self):
+        source = _source_task()
+        self._run(["win11-64-24h2-hw-alpha"], sources=[source])
+        self.assertEqual(source["task"]["workerType"], "win11-64-24h2-hw-ref")
+        self.assertEqual(source["task"]["routes"][0].split(".")[0], "index")
+        self.assertIn("treeherder", source["task"]["extra"])
+
+
+class TestCloudAndHwSelectionAreDisjoint(unittest.TestCase):
+    """The two target-tasks methods must never select each other's tasks."""
+
+    def test_attribute_namespaces_do_not_overlap(self):
+        cloud_attrs = {"replicate": "gecko"}
+        hw_attrs = {"hw_replicate": "gecko-hw", "hw_pool": "win11-64-24h2-hw-alpha"}
+
+        # mirrors target.py::integration and hw_target.py::hw_integration
+        self.assertIn("replicate", cloud_attrs)
+        self.assertNotIn("replicate", hw_attrs)
+        self.assertIn("hw_replicate", hw_attrs)
+        self.assertNotIn("hw_replicate", cloud_attrs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/taskcluster/worker_images_taskgraph/__init__.py
+++ b/taskcluster/worker_images_taskgraph/__init__.py
@@ -13,7 +13,7 @@ def register(graph_config):
     register_mozilla_taskgraph(graph_config)
 
     # Import sibling modules, triggering decorators in the process
-    _import_modules(["optimize", "target"])
+    _import_modules(["optimize", "target", "hw_target"])
 
 
 def _import_modules(modules):

--- a/taskcluster/worker_images_taskgraph/hw_target.py
+++ b/taskcluster/worker_images_taskgraph/hw_target.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.target_tasks import register_target_task
+
+
+@register_target_task("hw-integration")
+def hw_integration(full_task_graph, parameters, graph_config):
+    """Hardware tasks only: keyed on ``hw_replicate``, not target.py's
+    ``replicate``, so the cloud and hardware runs stay disjoint."""
+    return [
+        label
+        for label, task in full_task_graph.tasks.items()
+        if "hw_replicate" in task.attributes
+    ]

--- a/taskcluster/worker_images_taskgraph/parameters.py
+++ b/taskcluster/worker_images_taskgraph/parameters.py
@@ -12,12 +12,16 @@ from voluptuous import Any, Required
 def get_defaults(repo_root):
     return {
         "images": None,
+        "hw_pools": None,
     }
 
 
 extend_parameters_schema(
     {
         Required("images"): Any(None, list[str]),
+        # Hardware pool names from pools.yml; selected by name rather than
+        # inferred from an image, since they have no worker-manager entry.
+        Required("hw_pools"): Any(None, list[str]),
     },
     defaults_fn=get_defaults,
 )
@@ -26,3 +30,6 @@ extend_parameters_schema(
 def get_decision_parameters(graph_config, parameters):
     if images := os.environ.get("DEPLOY_IMAGES"):
         parameters["images"] = json.loads(images)
+
+    if hw_pools := os.environ.get("DEPLOY_HW_POOLS"):
+        parameters["hw_pools"] = json.loads(hw_pools)

--- a/taskcluster/worker_images_taskgraph/transforms/hw_integration_test.py
+++ b/taskcluster/worker_images_taskgraph/transforms/hw_integration_test.py
@@ -1,0 +1,214 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Replicate mozilla-central's Windows hardware test tasks onto MDC1 HW pools.
+
+Not built on mozilla_taskgraph's replicate transform: that discards every
+releng-hardware task before consulting config, and bumping it would affect the
+cloud integration-test kind. Namespaced away from the cloud path throughout.
+"""
+
+import logging
+import os
+from copy import deepcopy
+from pathlib import Path
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.taskcluster import find_task_id, get_artifact
+
+from worker_images_taskgraph.util.hw_pools import (
+    HwPoolError,
+    load_registry,
+)
+
+logger = logging.getLogger(__name__)
+transforms = TransformSequence()
+
+# Replaced wholesale: the source tasks carry mozilla-central's own index and
+# treeherder routes, which a retargeted run must not write to.
+KEPT_ROUTES: list[str] = []
+
+_CACHE_SCOPE_PREFIX = "generic-worker:cache:"
+_OS_GROUP_SCOPE_PREFIX = "generic-worker:os-group:"
+
+
+def _repo_root(config) -> Path:
+    root_dir = getattr(config.graph_config, "root_dir", None)
+    if root_dir:
+        candidate = Path(root_dir).parent
+        if (candidate / "provisioners").is_dir():
+            return candidate
+    from worker_images_taskgraph.util.hw_pools import find_repo_root
+
+    return find_repo_root()
+
+
+def _fetch_source_tasks(index: str, provisioner: str, prefixes: tuple[str, ...]):
+    """Return hardware task definitions from a decision task's scheduled graph."""
+    decision_task_id = find_task_id(index)
+    task_graph = get_artifact(decision_task_id, "public/task-graph.json")
+
+    matched = []
+    for label, task_def in sorted(task_graph.items()):
+        task = task_def.get("task", {})
+        if task.get("provisionerId") != provisioner:
+            continue
+        worker_type = task.get("workerType", "")
+        if not any(worker_type.startswith(p) for p in prefixes):
+            continue
+        task_def.setdefault("label", label)
+        matched.append(task_def)
+
+    logger.info(
+        f"hw-integration: {len(matched)} hardware task(s) in {index} "
+        f"(decision {decision_task_id})"
+    )
+    if not matched:
+        logger.warning(
+            f"hw-integration: no {provisioner} tasks matching {prefixes} were "
+            f"scheduled by {index}; nothing to replicate"
+        )
+    return matched
+
+
+def _rewrite_scopes(task, old_pool: str, new_pool: str, cache_from: str, cache_to: str):
+    """Keep holdable scopes, retarget pool-bound, drop the rest: an unholdable
+    scope fails task creation, a dropped one only affects its own task."""
+    kept, dropped = [], []
+    for scope in task.get("scopes", []):
+        if scope.startswith(_CACHE_SCOPE_PREFIX):
+            kept.append(scope.replace(cache_from, cache_to))
+        elif scope.startswith(_OS_GROUP_SCOPE_PREFIX):
+            kept.append(scope.replace(old_pool, new_pool))
+        else:
+            dropped.append(scope)
+
+    if dropped:
+        logger.info(
+            "hw-integration: dropped un-holdable scope(s) from "
+            f"{task['metadata']['name']}: {', '.join(sorted(dropped))}"
+        )
+    task["scopes"] = kept
+
+
+def _rewrite_caches(task, cache_from: str, cache_to: str):
+    payload = task.get("payload", {})
+
+    if cache := payload.get("cache"):
+        payload["cache"] = {k.replace(cache_from, cache_to): v for k, v in cache.items()}
+
+    for mount in payload.get("mounts", []):
+        if "cacheName" in mount:
+            mount["cacheName"] = mount["cacheName"].replace(cache_from, cache_to)
+
+
+def _rewrite_datestamps(task):
+    """Absolute datestamps from a completed task cannot be resubmitted."""
+    task["created"] = {"relative-datestamp": "0 seconds"}
+    task["deadline"] = {"relative-datestamp": "1 day"}
+    task["expires"] = {"relative-datestamp": "1 month"}
+
+    artifacts = task.get("payload", {}).get("artifacts")
+    if artifacts:
+        entries = artifacts.values() if isinstance(artifacts, dict) else artifacts
+        for artifact in entries:
+            if "expires" in artifact:
+                artifact["expires"] = {"relative-datestamp": "1 month"}
+
+
+@transforms.add
+def replicate_onto_hw_pools(config, tasks):
+    requested = list(config.params.get("hw_pools") or [])
+
+    for task in tasks:
+        replicate_config = task.pop("hw-replicate")
+
+        # Ordinary push/PR decision: emit nothing and make no network calls.
+        if not requested:
+            logger.debug(
+                f"hw-integration: no hw_pools requested, skipping {config.kind}"
+            )
+            continue
+
+        registry = load_registry(_repo_root(config))
+        try:
+            pools = registry.resolve(requested)
+        except HwPoolError as exc:
+            raise HwPoolError(f"hw-integration: {exc}") from exc
+
+        provisioner = replicate_config["provisioner"]
+        prefixes = tuple(replicate_config["worker-type-prefixes"])
+        source_tasks = _fetch_source_tasks(
+            replicate_config["target"], provisioner, prefixes
+        )
+
+        trust_domain = config.graph_config["trust-domain"]
+        level = config.params["level"]
+        scheduler_id = f"{trust_domain}-level-{level}"
+        cache_to = f"{trust_domain}-level-{level}-"
+
+        for pool in pools:
+            logger.info(
+                f"hw-integration: targeting {pool.task_queue_id} "
+                f"(image={pool.image} branch={pool.src_branch} rev={pool.revision} "
+                f"nodes={pool.node_count})"
+            )
+            if pool.is_low_capacity:
+                logger.warning(
+                    f"hw-integration: {pool.name} has only {pool.node_count} "
+                    "node(s); the task graph will serialise across them"
+                )
+
+            for source in source_tasks:
+                yield _build_task(
+                    source,
+                    task_name=task["name"],
+                    pool=pool,
+                    scheduler_id=scheduler_id,
+                    cache_to=cache_to,
+                )
+
+
+def _build_task(source, task_name, pool, scheduler_id, cache_to):
+    task_def = deepcopy(source)
+    task = task_def["task"]
+
+    old_pool = f"{task['provisionerId']}/{task['workerType']}"
+    new_pool = pool.task_queue_id
+    # Derived from the source scheduler so `-pip`/`-uv` suffixes survive.
+    cache_from = f"{source['task'].get('schedulerId', 'gecko-level-3')}-"
+
+    task["workerType"] = pool.name
+    task["schedulerId"] = scheduler_id
+    task["taskGroupId"] = os.environ["TASK_ID"]
+    task["priority"] = "low"
+    task["routes"] = list(KEPT_ROUTES)
+    task.get("extra", {}).pop("treeherder", None)
+
+    _rewrite_caches(task, cache_from, cache_to)
+    _rewrite_scopes(task, old_pool, new_pool, cache_from, cache_to)
+    _rewrite_datestamps(task)
+
+    # `*_REV` is kept, unlike the cloud path: the resolved dependency task ids
+    # point at builds of exactly this revision.
+
+    original_name = task["metadata"]["name"]
+    label = f"{task_name}-{pool.name}-{original_name}"
+    task["metadata"]["name"] = label
+
+    return {
+        "label": label,
+        # Dependencies are already concrete task ids; nothing to resolve by label.
+        "dependencies": {},
+        "description": task["metadata"].get("description", ""),
+        "task": task,
+        "attributes": {
+            "hw_replicate": task_name,
+            "hw_pool": pool.name,
+            "hw_source_label": source.get("label", original_name),
+            "hw_pool_image": pool.image,
+            "hw_pool_branch": pool.src_branch,
+            "hw_pool_revision": pool.revision,
+        },
+    }

--- a/taskcluster/worker_images_taskgraph/util/hw_pools.py
+++ b/taskcluster/worker_images_taskgraph/util/hw_pools.py
@@ -1,0 +1,191 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Registry for the MDC1 Windows hardware worker pools.
+
+Hardware pools are static workers with no worker-manager entry, so pools.yml is
+the only record of what each one is running. Imported by both the decision task
+and ci/run-hw-os-integration.py, so PyYAML is the only dependency.
+"""
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+PROVISIONER_ID = "releng-hardware"
+
+POOLS_YAML_RELPATH = Path("provisioners/windows/MDC1Windows/pools.yml")
+
+# Production pools are the ones mozilla-central addresses directly, via its
+# `win11-64-24h2(-hw|-hw-ref)` alias. Derived so a new one is refused on sight.
+_PRODUCTION_RE = re.compile(r"^win11-(?:64|a64)-[0-9a-z]+-hw(?:-ref)?$")
+
+LOW_CAPACITY_THRESHOLD = 4
+
+
+class HwPoolError(Exception):
+    """Raised when a requested hardware pool is unknown or not targetable."""
+
+
+@dataclass(frozen=True)
+class HwPool:
+    """One entry from the ``pools`` list in ``pools.yml``."""
+
+    name: str
+    image: str | None = None
+    src_organisation: str | None = None
+    src_repository: str | None = None
+    src_branch: str | None = None
+    revision: str | None = None
+    secret_date: str | None = None
+    domain_suffix: str | None = None
+    description: str | None = None
+    dev_branch: str | None = None
+    nodes: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def task_queue_id(self) -> str:
+        return f"{PROVISIONER_ID}/{self.name}"
+
+    @property
+    def is_production(self) -> bool:
+        return bool(_PRODUCTION_RE.match(self.name))
+
+    @property
+    def node_count(self) -> int:
+        return len(self.nodes)
+
+    @property
+    def is_low_capacity(self) -> bool:
+        return self.node_count < LOW_CAPACITY_THRESHOLD
+
+    @property
+    def identity(self) -> dict[str, str | None]:
+        """The WIM + ronin triple a test result has to be attributed to."""
+        return {
+            "image": self.image,
+            "src_branch": self.src_branch,
+            "revision": self.revision,
+        }
+
+    def fqdn(self, node: str) -> str:
+        if not self.domain_suffix:
+            return node
+        return f"{node}.{self.domain_suffix}"
+
+
+@dataclass(frozen=True)
+class HwPoolRegistry:
+    pools: dict[str, HwPool]
+    known_bad_nodes: frozenset[str]
+
+    def __contains__(self, name: object) -> bool:
+        return name in self.pools
+
+    def __getitem__(self, name: str) -> HwPool:
+        return self.pools[name]
+
+    @property
+    def targetable(self) -> dict[str, HwPool]:
+        return {n: p for n, p in self.pools.items() if not p.is_production}
+
+    def healthy_nodes(self, name: str) -> tuple[str, ...]:
+        return tuple(n for n in self[name].nodes if n not in self.known_bad_nodes)
+
+    def resolve(self, names) -> list[HwPool]:
+        """Validate requested pool names, returning them in pools.yml order."""
+        requested = list(dict.fromkeys(names))
+        if not requested:
+            raise HwPoolError("no hardware pools requested")
+
+        unknown = [n for n in requested if n not in self.pools]
+        if unknown:
+            raise HwPoolError(
+                "unknown hardware pool(s): {}. Known pools: {}".format(
+                    ", ".join(sorted(unknown)),
+                    ", ".join(sorted(self.pools)),
+                )
+            )
+
+        # Last line of defence if the hook is triggered by hand.
+        production = [n for n in requested if self[n].is_production]
+        if production:
+            raise HwPoolError(
+                "refusing to target production hardware pool(s): {}. "
+                "These pools run production Firefox CI.".format(
+                    ", ".join(sorted(production))
+                )
+            )
+
+        return [p for n, p in self.pools.items() if n in requested]
+
+
+def find_repo_root(start: Path | str | None = None) -> Path:
+    """Walk up from ``start`` looking for the checkout containing pools.yml."""
+    here = Path(start).resolve() if start else Path(__file__).resolve()
+    for candidate in (here, *here.parents):
+        if (candidate / POOLS_YAML_RELPATH).is_file():
+            return candidate
+    raise HwPoolError(
+        f"could not locate {POOLS_YAML_RELPATH} above {here}; "
+        "is this a worker-images checkout?"
+    )
+
+
+def _coerce_nodes(raw) -> tuple[str, ...]:
+    if not raw:
+        return ()
+    return tuple(str(n).strip() for n in raw if str(n).strip())
+
+
+def _parse_known_bad(raw) -> frozenset[str]:
+    """Flatten the ``Known-BAD`` mapping of hw-class -> node list."""
+    if not isinstance(raw, dict):
+        return frozenset()
+    nodes: set[str] = set()
+    for entries in raw.values():
+        nodes.update(_coerce_nodes(entries))
+    return frozenset(nodes)
+
+
+def load_registry(repo_root: Path | str | None = None) -> HwPoolRegistry:
+    """Parse ``pools.yml`` into an :class:`HwPoolRegistry`."""
+    root = Path(repo_root) if repo_root else find_repo_root()
+    pools_yaml = root / POOLS_YAML_RELPATH
+    if not pools_yaml.is_file():
+        raise HwPoolError(f"{pools_yaml} does not exist")
+
+    data = yaml.safe_load(pools_yaml.read_text()) or {}
+
+    pools: dict[str, HwPool] = {}
+    for entry in data.get("pools") or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip()
+        if not name:
+            continue
+        pools[name] = HwPool(
+            name=name,
+            image=entry.get("image"),
+            src_organisation=entry.get("src_Organisation"),
+            src_repository=entry.get("src_Repository"),
+            src_branch=entry.get("src_Branch"),
+            # pools.yml `hash` is the ronin_puppet pin; renamed to avoid the builtin.
+            revision=entry.get("hash"),
+            secret_date=entry.get("secret_date"),
+            domain_suffix=entry.get("domain_suffix"),
+            description=entry.get("Description"),
+            dev_branch=entry.get("dev"),
+            nodes=_coerce_nodes(entry.get("nodes")),
+        )
+
+    if not pools:
+        raise HwPoolError(f"no pools found in {pools_yaml}")
+
+    return HwPoolRegistry(
+        pools=pools,
+        known_bad_nodes=_parse_known_bad(data.get("Known-BAD")),
+    )


### PR DESCRIPTION
[RELOPS-2503](https://mozilla-hub.atlassian.net/browse/RELOPS-2503)

## Why

Validating a Windows HW change — a baked `install.wim` or a ronin_puppet change — currently means a try push and waiting on shippable try builds before any HW test task can run. That serialises image and config validation behind Firefox build turnaround.

worker-images already solves this for cloud images (`os-integration.yml` → the `run-integration-tests` cron hook → replicate mozilla-central's `os-integration` graph onto `-alpha` pools). This is the hardware counterpart: a dispatchable workflow that runs the in-tree Windows HW test tasks against selected `releng-hardware` pools, using builds that already exist in the mozilla-central index.

## Why it isn't just a copy of the cloud path

Two things ruled that out:

1. **HW pools don't exist in worker-manager.** All 391 `listWorkerPools` entries are cloud (`aws`, `azure2`, `azure_trusted`, `fxci-level{1,3}-gcp`); zero `releng-hardware`. They're static workers with per-pool clients in fxci-config. So `util/fxci.py::get_worker_pool_images` has nothing to work with and the image→pool inference can't apply. Pools are selected **by name**, and `provisioners/windows/MDC1Windows/pools.yml` is the only record of what each is running.
2. **`mozilla_taskgraph.transforms.replicate` can never emit a HW task.** It drops `provisionerId == "releng-hardware"` (and anything with `runAsAdministrator`) before any config is consulted, and reads `public/task-graph.json` from a hardcoded path. Rather than bump a dependency the cloud decision shares, `hw_integration_test` does the equivalent work locally.

## Isolation from the cloud path

Deliberately disjoint namespaces so a HW run and a cloud run can't select each other's tasks:

| | cloud | hardware |
|---|---|---|
| attribute | `replicate` | `hw_replicate` |
| target-tasks method | `integration` | `hw-integration` |
| cron job | `run-integration-tests` | `run-hw-integration-tests` |
| kind | `integration-test` | `hw-integration-test` |
| parameter | `images` | `hw_pools` |

`integration_test.py`, `optimize.py`, `util/fxci.py`, `os-integration.yml` and `run-os-integration.py` are untouched. `mozilla-taskgraph` is unchanged. The four shared files get +13/+3/+9/+1 additive lines.

## Safety

- **Production pools refused.** Derived from the naming rule mozilla-central uses to address them (`-hw` / `-hw-ref` with no further suffix) rather than a deny list, so a future `win11-64-25h2-hw` is refused the day it's added.
- **Pre-flight before any hardware time.** Asserts live workers per pool and reports drift between Taskcluster and `pools.yml`. It already found real drift: `relops1213` shows `nuc13-045` actively claiming while `pools.yml` assigns it to `hw-alpha`, i.e. not redeployed since it was moved.
- **Zero tasks is a failure**, not a pass.
- **Gecko `index.*` / `tc-treeherder.*` routes and `extra.treeherder` are stripped**, so a retargeted run can't overwrite mozilla-central index entries or report as a real mc task.
- **Unholdable scopes are dropped, not carried, and every drop is logged.** Carrying one would fail task *creation* and take the whole run down; dropping only affects the task that needed it.

## Testing

- 23/23 `taskcluster/test` green (was 4); 19 new tests cover pool parsing, production refusal, worker-type retargeting, cache/scope consistency, secret-scope dropping, route/treeherder stripping, relative datestamps, `*_REV` preservation, source-task immutability, and attribute disjointness.
- `.taskcluster.yml` rendered through json-e for cron-with-pools, cron-with-images, both, neither, `github-push` and `github-issue-comment`.
- `load_graph_config` registers both `integration` and `hw-integration`; `integration-test` optimize strategy unchanged.
- `pre-commit run --files` clean.
- Live read-only exercise: `--list` shows 5 targetable pools and names the 2 refused; production pools exit 2; pre-flight passes `relops1213` and refuses `perf-sheriff` (0 active workers).

## Deliberate calls, easily reversed

- **Source is the mc _push_ decision**, not `decision-os-integration`, which schedules **no** HW tasks (0 in `target-tasks.json`, though 34 appear in `runnable-jobs.json`). A push schedules 3 with dependencies already resolved to real completed builds. Broadening needs a dependency resolver — one line in `kind.yml` to change the source.
- **No Perfherder ingestion** as a consequence of stripping treeherder config. Intent is to scrape `perfherder-data.json` artifacts; not built yet.

## Blocked on fxci-config (this PR is inert without it)

- `projects.yml`: add `run-hw-integration-tests` to worker-images `cron.targets` with `allow-input: true` — targets are enumerated explicitly, so `.cron.yml` alone does nothing.
- `grants.d/releng.yml`: a **separate** grant for `job: [cron:run-hw-integration-tests]` with `queue:create-task` on the five non-prod `releng-hardware/win11-64-24h2-hw-*` queues. Do not extend the shared `&os-integration` anchor — fxci-config's own staging PR job uses it. Note this asks for level-3 MDC1 hardware where the existing grant is deliberately limited to level-1 `gecko-t/*`.
- `clients.yml`: add `hooks:trigger-hook:…/run-hw-integration-tests` to the existing `project/relops/worker-images/run-integration-tests` client, so current GitHub Actions secrets are reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
