### PR TITLE
RELOPS-2504: add linux sboms

### DIFF
--- a/.github/workflows/gcp-deploy-parallel.yml
+++ b/.github/workflows/gcp-deploy-parallel.yml
@@ -98,3 +98,50 @@ jobs:
           --source-image ${{ steps.set-gcp-vars.outputs.IMAGENAME }} `
           --source-image-project ${{ steps.set-gcp-vars.outputs.PROJECT }} `
           --force
+
+      - id: create-production-sbom
+        name: Create Production SBOM Record
+        shell: pwsh
+        run: |
+          $date = Get-Date -Format "yyyy-MM-dd"
+          $ProdImageName = -join(('${{ steps.set-gcp-vars.outputs.IMAGENAME }}' -Replace "alpha"),$date)
+          $AlphaImageName = '${{ steps.set-gcp-vars.outputs.IMAGENAME }}'
+          $AlphaSbomPath = "sboms/$AlphaImageName.md"
+          $ProductionSbomPath = "sboms/$ProdImageName.md"
+          $AlphaSbomHash = (Get-FileHash -Algorithm SHA256 $AlphaSbomPath).Hash.ToLowerInvariant()
+          $PromotionTimestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+          $Header = @"
+          # Production deployment record
+
+          - Production image name: ``$ProdImageName``
+          - Alpha source image name: ``$AlphaImageName``
+          - Promotion timestamp: ``$PromotionTimestamp``
+          - Promotion copied the alpha image without rebuilding the filesystem.
+          - SHA-256 of the unmodified alpha SBOM: ``$AlphaSbomHash``
+
+          ---
+
+          "@
+          $HeaderBytes = [System.Text.Encoding]::UTF8.GetBytes($Header)
+          $AlphaSbomBytes = [System.IO.File]::ReadAllBytes((Resolve-Path $AlphaSbomPath))
+          [System.IO.File]::WriteAllBytes($ProductionSbomPath, $HeaderBytes + $AlphaSbomBytes)
+          "production_sbom=$ProductionSbomPath" >> $env:GITHUB_OUTPUT
+
+      - name: Upload Production SBOM Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: release-notes-production-${{ matrix.config }}
+          path: ${{ steps.create-production-sbom.outputs.production_sbom }}
+          overwrite: true
+          retention-days: 1
+          if-no-files-found: error
+
+  sbom:
+    needs: prodimage
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/upload-release-notes.yml
+    with:
+      artifact_pattern: release-notes-production-*
+      commit_message: GCP Production Release Notes

--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -81,3 +81,50 @@ jobs:
           --source-image ${{ needs.setproject.outputs.IMAGENAME }} `
           --source-image-project ${{ needs.setproject.outputs.PROJECT }} `
           --force
+
+      - id: create-production-sbom
+        name: Create Production SBOM Record
+        shell: pwsh
+        run: |
+          $date = Get-Date -Format "yyyy-MM-dd"
+          $ProdImageName = -join(('${{ needs.setproject.outputs.IMAGENAME }}' -Replace "alpha"),$date)
+          $AlphaImageName = '${{ needs.setproject.outputs.IMAGENAME }}'
+          $AlphaSbomPath = "sboms/$AlphaImageName.md"
+          $ProductionSbomPath = "sboms/$ProdImageName.md"
+          $AlphaSbomHash = (Get-FileHash -Algorithm SHA256 $AlphaSbomPath).Hash.ToLowerInvariant()
+          $PromotionTimestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+          $Header = @"
+          # Production deployment record
+
+          - Production image name: ``$ProdImageName``
+          - Alpha source image name: ``$AlphaImageName``
+          - Promotion timestamp: ``$PromotionTimestamp``
+          - Promotion copied the alpha image without rebuilding the filesystem.
+          - SHA-256 of the unmodified alpha SBOM: ``$AlphaSbomHash``
+
+          ---
+
+          "@
+          $HeaderBytes = [System.Text.Encoding]::UTF8.GetBytes($Header)
+          $AlphaSbomBytes = [System.IO.File]::ReadAllBytes((Resolve-Path $AlphaSbomPath))
+          [System.IO.File]::WriteAllBytes($ProductionSbomPath, $HeaderBytes + $AlphaSbomBytes)
+          "production_sbom=$ProductionSbomPath" >> $env:GITHUB_OUTPUT
+
+      - name: Upload Production SBOM Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: release-notes-production-${{ github.event.inputs.config }}
+          path: ${{ steps.create-production-sbom.outputs.production_sbom }}
+          overwrite: true
+          retention-days: 1
+          if-no-files-found: error
+
+  sbom:
+    needs: prodimage
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/upload-release-notes.yml
+    with:
+      artifact_pattern: release-notes-production-${{ github.event.inputs.config }}
+      commit_message: ${{ github.event.inputs.config }} - Production Release Notes

--- a/.github/workflows/gcp-fxci-parallel-alpha.yml
+++ b/.github/workflows/gcp-fxci-parallel-alpha.yml
@@ -103,6 +103,23 @@ jobs:
           }
           New-GCPWorkerImage @Vars
 
+      - name: Upload Release Notes Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: release-notes-${{ matrix.config }}
+          path: sboms/${{ steps.set-gcp-vars.outputs.IMAGENAME }}.md
+          overwrite: true
+          retention-days: 1
+          if-no-files-found: error
+
+  sbom:
+    if: ${{ always() }}
+    needs: [prepare-matrix, packer]
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/upload-release-notes.yml
+
   find-successful-builds:
     needs: [prepare-matrix, packer]
     name: "Filter matrices to successful packer builds"

--- a/.github/workflows/gcp-fxci.yml
+++ b/.github/workflows/gcp-fxci.yml
@@ -76,6 +76,26 @@ jobs:
             Key = '${{ github.event.inputs.config }}'
           }
           New-GCPWorkerImage @Vars
+
+      - name: Upload Release Notes Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: release-notes-${{ github.event.inputs.config }}
+          path: sboms/${{ needs.setproject.outputs.IMAGENAME }}.md
+          overwrite: true
+          retention-days: 1
+          if-no-files-found: error
+
+  sbom:
+    needs: packer
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/upload-release-notes.yml
+    with:
+      artifact_pattern: release-notes-${{ github.event.inputs.config }}
+      commit_message: ${{ github.event.inputs.config }} - Release Notes
+
   wiz:
     needs: [packer, setproject]
     name: "Wiz scan ${{ github.event.inputs.config }}"

--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -322,6 +322,35 @@ build {
     start_retry_timeout = "30m"
   }
 
+  provisioner "file" {
+    source      = "${path.cwd}/scripts/linux/common/generate-sbom.sh"
+    destination = "/tmp/generate-linux-sbom.sh"
+  }
+
+  provisioner "shell" {
+    execute_command = "sudo -S bash -c '{{ .Vars }} {{ .Path }}'"
+    environment_vars = [
+      "IMAGE_NAME=${var.image_name}",
+      "TASKCLUSTER_VERSION=${var.taskcluster_version}",
+      "TASKCLUSTER_REF=${var.taskcluster_ref}",
+      "TC_ARCH=${var.tc_arch}",
+      "SOURCE_IMAGE_FAMILY=${var.source_image_family}",
+      "PROJECT_ID=${var.project_id}",
+      "ZONE=${var.zone}"
+    ]
+    inline = [
+      "bash /tmp/generate-linux-sbom.sh",
+      "rm -f /tmp/generate-linux-sbom.sh"
+    ]
+  }
+
+  provisioner "file" {
+    destination = "${path.cwd}/sboms/${var.image_name}.md"
+    direction   = "download"
+    max_retries = 3
+    source      = "/etc/worker-images/SBOM.md"
+  }
+
   post-processor "manifest" {
     output     = "packer-artifacts.json"
     strip_path = true

--- a/scripts/linux/common/generate-sbom.sh
+++ b/scripts/linux/common/generate-sbom.sh
@@ -39,6 +39,27 @@ write_taskcluster_tools() {
   fi
 }
 
+os_release_value() {
+  local key="$1"
+
+  awk -F= -v key="${key}" '
+    $1 == key {
+      value = substr($0, length(key) + 2)
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "${os_release_path}"
+}
+
+os_name_and_version() {
+  local name version
+
+  name="$(os_release_value NAME)"
+  version="$(os_release_value VERSION)"
+  printf '%s %s' "${name:-unknown}" "${version:-unknown}"
+}
+
 {
   printf '# Linux worker image SBOM\n\n'
 
@@ -52,7 +73,7 @@ write_taskcluster_tools() {
   printf -- '- GCP zone: %s\n\n' "${ZONE:-unknown}"
 
   printf '## Operating system\n\n'
-  printf -- '- OS: %s\n' "$(. "${os_release_path}"; printf '%s %s' "${NAME}" "${VERSION}")"
+  printf -- '- OS: %s\n' "$(os_name_and_version)"
   printf -- '- Kernel: %s\n' "$(uname -srmo)"
   printf -- '- Machine architecture: %s\n\n' "$(uname -m)"
 

--- a/scripts/linux/common/generate-sbom.sh
+++ b/scripts/linux/common/generate-sbom.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output_path="${SBOM_OUTPUT:-/etc/worker-images/SBOM.md}"
+output_dir="$(dirname "${output_path}")"
+os_release_path="${OS_RELEASE_PATH:-/etc/os-release}"
+mkdir -p "${output_dir}"
+temporary_output="$(mktemp "${output_path}.XXXXXX")"
+
+cleanup() {
+  rm -f "${temporary_output}"
+}
+trap cleanup EXIT
+
+markdown_table_row() {
+  local value
+  for value in "$@"; do
+    value="${value//|/\\|}"
+    printf '| %s ' "${value}"
+  done
+  printf '|\n'
+}
+
+write_taskcluster_tools() {
+  local tool tool_path version
+  local found_tool=false
+
+  for tool in generic-worker start-worker livelog taskcluster-proxy; do
+    if tool_path="$(command -v "${tool}" 2>/dev/null)"; then
+      version="$("${tool_path}" --version 2>&1 | head -n 1 || true)"
+      markdown_table_row "${tool}" "${version:-installed (version unavailable)}"
+      found_tool=true
+    fi
+  done
+
+  if [[ "${found_tool}" == false ]]; then
+    markdown_table_row "None" "No Taskcluster tools found in PATH"
+  fi
+}
+
+{
+  printf '# Linux worker image SBOM\n\n'
+
+  printf '## Build provenance\n\n'
+  printf -- '- Image name: %s\n' "${IMAGE_NAME:-unknown}"
+  printf -- '- Taskcluster version: %s\n' "${TASKCLUSTER_VERSION:-unknown}"
+  printf -- '- Taskcluster ref: %s\n' "${TASKCLUSTER_REF:-unknown}"
+  printf -- '- Architecture: %s\n' "${TC_ARCH:-unknown}"
+  printf -- '- Source image family: %s\n' "${SOURCE_IMAGE_FAMILY:-unknown}"
+  printf -- '- GCP project: %s\n' "${PROJECT_ID:-unknown}"
+  printf -- '- GCP zone: %s\n\n' "${ZONE:-unknown}"
+
+  printf '## Operating system\n\n'
+  printf -- '- OS: %s\n' "$(. "${os_release_path}"; printf '%s %s' "${NAME}" "${VERSION}")"
+  printf -- '- Kernel: %s\n' "$(uname -srmo)"
+  printf -- '- Machine architecture: %s\n\n' "$(uname -m)"
+
+  printf '## Taskcluster tools\n\n'
+  markdown_table_row 'Name' 'Version'
+  markdown_table_row '---' '---'
+  write_taskcluster_tools
+  printf '\n'
+
+  printf '## Python packages\n\n'
+  markdown_table_row 'Name' 'Version'
+  markdown_table_row '---' '---'
+  if python3 -m pip list --format=freeze 2>/dev/null | while IFS='=' read -r name version; do
+    markdown_table_row "${name}" "${version#=}"
+  done; then
+    :
+  else
+    markdown_table_row 'None' 'python3 pip is unavailable'
+  fi
+  printf '\n'
+
+  printf '## dpkg packages\n\n'
+  markdown_table_row 'Name' 'Version' 'Architecture'
+  markdown_table_row '---' '---' '---'
+  while IFS=$'\t' read -r name version architecture; do
+    markdown_table_row "${name}" "${version}" "${architecture}"
+  done < <(dpkg-query -W -f='${binary:Package}\t${Version}\t${Architecture}\n' | LC_ALL=C sort)
+} > "${temporary_output}"
+
+mv "${temporary_output}" "${output_path}"
+chmod 0644 "${output_path}"
+trap - EXIT

--- a/tests/linux/test_generate_sbom.sh
+++ b/tests/linux/test_generate_sbom.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+generator="${repo_root}/scripts/linux/common/generate-sbom.sh"
+test_dir="$(mktemp -d)"
+mock_bin="${test_dir}/bin"
+output_path="${test_dir}/SBOM.md"
+os_release_path="${test_dir}/os-release"
+
+cleanup() {
+  rm -rf "${test_dir}"
+}
+trap cleanup EXIT
+
+mkdir -p "${mock_bin}"
+
+printf '%s\n' 'NAME="Ubuntu"' 'VERSION="24.04 LTS"' > "${os_release_path}"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'printf "sample-package\t1.2.3\tamd64\n"' > "${mock_bin}/dpkg-query"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'if [[ "$*" == "-m pip list --format=freeze" ]]; then' \
+  '  printf "sample-python-package==4.5.6\n"' \
+  'fi' > "${mock_bin}/python3"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'case "$1" in' \
+  '  -srmo) printf "Linux 6.8.0 test x86_64\n" ;;' \
+  '  -m) printf "x86_64\n" ;;' \
+  'esac' > "${mock_bin}/uname"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'printf "generic-worker 100.4.0\n"' > "${mock_bin}/generic-worker"
+chmod +x "${mock_bin}"/*
+
+PATH="${mock_bin}:${PATH}" \
+IMAGE_NAME='test-image' \
+TASKCLUSTER_VERSION='100.4.0' \
+TASKCLUSTER_REF='v100.4.0' \
+TC_ARCH='amd64' \
+SOURCE_IMAGE_FAMILY='ubuntu-2404' \
+PROJECT_ID='test-project' \
+ZONE='us-west1-a' \
+SBOM_OUTPUT="${output_path}" \
+OS_RELEASE_PATH="${os_release_path}" \
+bash "${generator}"
+
+grep -Fqx '# Linux worker image SBOM' "${output_path}"
+grep -Fqx -- '- Image name: test-image' "${output_path}"
+grep -Fqx -- '- Kernel: Linux 6.8.0 test x86_64' "${output_path}"
+grep -Fqx -- '- OS: Ubuntu 24.04 LTS' "${output_path}"
+grep -Fqx '| generic-worker | generic-worker 100.4.0 |' "${output_path}"
+grep -Fqx '| sample-python-package | 4.5.6 |' "${output_path}"
+grep -Fqx '| sample-package | 1.2.3 | amd64 |' "${output_path}"


### PR DESCRIPTION
Adds linux SBOM generation and upload to alpha image builds. On promotion, we copy the alpha sbom.md to the prod image name.md and add a deployment header to the new prod sbom.

See https://mozilla-hub.atlassian.net/browse/RELOPS-2504.