### PR TITLE
win-hw-wim-build: add 'iso' stage option (requirement-bypass Win11 ISO)

### DIFF
--- a/.github/workflows/win-hw-wim-build.yml
+++ b/.github/workflows/win-hw-wim-build.yml
@@ -21,17 +21,12 @@ on:
         type: choice
         default: win11-24h2-hw
         # Keep in sync with provisioners/windows/win-hw-wim/config/*.yaml on the pipeline branch.
+        # win11-24h2-iso builds a requirement-bypass Win11 ISO (its config sets iso.enabled: true);
+        # the others run the normal WIM bake. Selection is config-driven - just pick the image.
         options:
           - win11-24h2-hw
           - win11-24h2-hw-test
           - win11-24h2-iso
-      stages:
-        description: "Pipeline stages (blank = prep,build,publish bake; 'iso' = build the requirement-bypass Win11 ISO)"
-        type: choice
-        default: ""
-        options:
-          - ""
-          - iso
       pipeline_ref:
         description: "worker-images branch holding provisioners/windows/win-hw-wim"
         type: string
@@ -88,7 +83,6 @@ jobs:
         shell: pwsh
         env:
           IMAGE: ${{ inputs.image }}
-          STAGES: ${{ inputs.stages }}
           PIPELINE_REF: ${{ inputs.pipeline_ref }}
           BUILD_ID: ${{ inputs.build_id }}
         run: ./ci/kickoff-win-hw-wim-build.ps1

--- a/.github/workflows/win-hw-wim-build.yml
+++ b/.github/workflows/win-hw-wim-build.yml
@@ -24,6 +24,14 @@ on:
         options:
           - win11-24h2-hw
           - win11-24h2-hw-test
+          - win11-24h2-iso
+      stages:
+        description: "Pipeline stages (blank = prep,build,publish bake; 'iso' = build the requirement-bypass Win11 ISO)"
+        type: choice
+        default: ""
+        options:
+          - ""
+          - iso
       pipeline_ref:
         description: "worker-images branch holding provisioners/windows/win-hw-wim"
         type: string
@@ -80,6 +88,7 @@ jobs:
         shell: pwsh
         env:
           IMAGE: ${{ inputs.image }}
+          STAGES: ${{ inputs.stages }}
           PIPELINE_REF: ${{ inputs.pipeline_ref }}
           BUILD_ID: ${{ inputs.build_id }}
         run: ./ci/kickoff-win-hw-wim-build.ps1


### PR DESCRIPTION
Adds a workflow_dispatch option to build a **requirement-bypass Windows 11 ISO** (TPM/Secure Boot/RAM/CPU/storage) via the existing win-hw-wim pipeline — a distinct function from the ronin base WIM bakes.

- New `stages` input: blank = default `prep,build,publish` bake; `iso` = run the ISO stage.
- New `win11-24h2-iso` image option (config `config/win11-24h2-iso.yaml` on the pipeline branch).
- Passes `STAGES` to `ci/kickoff-win-hw-wim-build.ps1`, which threads `-Stages` → `New-WinHwWim` on the build VM.

Pipeline/script support (create-iso.ps1, iso config, -Stages threading) is on `nuc-wim-pipeline`; this PR only exposes the option on the default-branch workflow (same pattern as the pool `dev:` trigger). Ref: https://woshub.com/upgrade-to-windows-11-unsupported-pc/

🤖 Generated with [Claude Code](https://claude.com/claude-code)