### PR TITLE
win-hw-wim-build: correct iso option to win11-25h2-iso (+ win11-25h2-hw)

### DIFF
--- a/.github/workflows/win-hw-wim-build.yml
+++ b/.github/workflows/win-hw-wim-build.yml
@@ -21,12 +21,13 @@ on:
         type: choice
         default: win11-24h2-hw
         # Keep in sync with provisioners/windows/win-hw-wim/config/*.yaml on the pipeline branch.
-        # win11-24h2-iso builds a requirement-bypass Win11 ISO (its config sets iso.enabled: true);
+        # win11-25h2-iso builds a requirement-bypass Win11 ISO (its config sets iso.enabled: true);
         # the others run the normal WIM bake. Selection is config-driven - just pick the image.
         options:
           - win11-24h2-hw
           - win11-24h2-hw-test
-          - win11-24h2-iso
+          - win11-25h2-hw
+          - win11-25h2-iso
       pipeline_ref:
         description: "worker-images branch holding provisioners/windows/win-hw-wim"
         type: string


### PR DESCRIPTION
Follow-up to #849. The base media uploaded to `nucwimfxci base/` is **Win11 25H2**
(`Win11_25H2_English_x64_v2.iso`), so on the pipeline branch (`nuc-wim-pipeline`) the
iso config was renamed `win11-24h2-iso` → `win11-25h2-iso` and a `win11-25h2-hw` WIM
bake config (with a base-WIM-from-ISO fallback) was added.

This corrects the `image` dropdown on `main` to match:
- `win11-24h2-iso` → `win11-25h2-iso` (the old option now points at a config that no longer exists)
- add `win11-25h2-hw`

Needed on `main` because the FXCI OIDC federated-identity credential only trusts
`refs/heads/main` — dispatching from a feature branch fails `AADSTS700213` at Azure
Login (observed on run 31128835379). Once merged, dispatch:
`gh workflow run "Windows HW WIM Build" --ref main -f image=win11-25h2-iso -f pipeline_ref=nuc-wim-pipeline`
→ output `base/win11-25h2-nocheck.iso`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)