### PR TITLE
RELOPS-2507: pin 25H2 alpha to NVMe startup fix

### DIFF
--- a/config/win11-64-25h2-alpha.yaml
+++ b/config/win11-64-25h2-alpha.yaml
@@ -29,7 +29,7 @@ vm:
     sourceOrganization: mozilla-platform-ops
     sourceRepository: ronin_puppet
     sourceBranch: "master"
-    deploymentId: "default"
+    deploymentId: "c1b0efe"
     managed_by: packer
 tests:
   - win11_sdk_tests.ps1


### PR DESCRIPTION
## Summary

- Pin the Windows 11 25H2 alpha image to Ronin revision c1b0efe.
- Limit the change to the alpha image. Keep the production default and all other image definitions unchanged.
- Keep alpha gallery version 1.0.0 and Packer build SKU Standard_D8ads_v5.

## Reason

Ronin revision c1b0efe prepares and verifies the NVMe D: drive before Worker Runner starts on Standard_F8alds_v7 and Standard_F8ads_v7. The alpha image must include this revision before the Taskcluster first-boot and Firefox tier 1 checks can start.

## Validation

- Confirmed that c1b0efe is the merged Ronin master revision.
- Ran pre-commit for config/win11-64-25h2-alpha.yaml.
- Confirmed that the resolved alpha values are deployment c1b0efe, gallery version 1.0.0, and build SKU Standard_D8ads_v5.
- Confirmed that the production default remains 82415f4.
- Completed the structured pre-ship review with no findings.

## Related

- [RELOPS-2507](https://mozilla-hub.atlassian.net/browse/RELOPS-2507)
- [RELOPS-2028 AMD migration epic](https://mozilla-hub.atlassian.net/browse/RELOPS-2028)
- [ronin_puppet PR #1319](https://github.com/mozilla-platform-ops/ronin_puppet/pull/1319)