### PR TITLE
win-hw-wim-build: RESOURCE_GROUP -> rg-central-us-hardware-imaging (merge at cutover)

### DIFF
--- a/.github/workflows/win-hw-wim-build.yml
+++ b/.github/workflows/win-hw-wim-build.yml
@@ -10,7 +10,7 @@ run-name: "Windows HW WIM build - ${{ inputs.image }} @ ${{ inputs.pipeline_ref 
 #   - Reuses the existing FXCI (nontrusted) image-creation OIDC credentials — the same
 #     SP/secrets as sig-nontrusted.yml: AZURE_CLIENT_ID_FXCI, AZURE_SUBSCRIPTION_ID_UNTRUSTED,
 #     AZURE_TENANT_ID. That SP must be able to create/delete VMs + run-command in
-#     rg-central-us-nuc-wim and assign the Storage Blob Data role (Contributor +
+#     rg-central-us-hardware-imaging and assign the Storage Blob Data role (Contributor +
 #     Role Based Access Control Administrator/User Access Administrator there).
 
 on:
@@ -59,7 +59,7 @@ jobs:
       id-token: write
       contents: read
     env:
-      RESOURCE_GROUP: rg-central-us-nuc-wim
+      RESOURCE_GROUP: rg-central-us-hardware-imaging
       # Run-scoped VM name so parallel runs don't collide and teardown is exact.
       VM_NAME: win-hw-wim-build-${{ github.run_id }}
     steps:


### PR DESCRIPTION
Part of the **nuc-wim → hardware-imaging** infra rebrand (RELOPS-2487 prod prep).

The build workflow hardcodes `RESOURCE_GROUP: rg-central-us-nuc-wim` as a job env, which
**overrides** the pipeline script defaults. Those scripts (`ci/win-hw-wim-vm.ps1`,
`ci/kickoff-win-hw-wim-build.ps1`, `New-WinHwWimBuildVm.ps1`) were already rebranded on
`nuc-wim-pipeline`, so this env var is the last reference that still points at the old RG.

Change: `RESOURCE_GROUP` env → `rg-central-us-hardware-imaging` (+ matching comment).

## ⚠️ MERGE AT CUTOVER ONLY
Do **not** merge this before the Terraform apply that creates `rg-central-us-hardware-imaging`
(relops_infra_as_code `nuc-wim-storage`). If merged first, GH builds create the ephemeral VM
in a non-existent RG and fail. Sequence:
1. `terraform apply` — create the new `hardware-imaging` RG/account/network/UAMI
2. migrate blobs old → new (folder remap)
3. **merge this PR** + push `nuc-wim-pipeline`
4. `terraform apply` — retire the old `nuc-wim` RG

🤖 Generated with [Claude Code](https://claude.com/claude-code)